### PR TITLE
Generate a Study Instance UID for each imaging request.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,6 +14,7 @@ def register():
         health_vara.Party,
         health_vara.MammographyPatient,
         health_vara.PatientEvaluation,
+        health_imaging.ImagingTestRequest,
         health_imaging.ImagingTestResult,
         health_imaging.ImagingFinding,
         health_imaging.BIRADS,

--- a/health_imaging.py
+++ b/health_imaging.py
@@ -21,6 +21,11 @@ class ImagingTestRequest(metaclass=PoolMeta):
     __name__ = 'gnuhealth.imaging.test.request'
 
     study_instance_uid = fields.Char('Study Instance UID')
+    accession_number = fields.Function(fields.Char(
+        'Accession Number'), 'get_accession_number')
+
+    def get_accession_number(self, _name):
+        return "MXH-" + str(self.id)
 
     @staticmethod
     def default_study_instance_uid():

--- a/health_imaging.py
+++ b/health_imaging.py
@@ -7,12 +7,24 @@ from trytond.modules.health.core import (
 from trytond.pool import PoolMeta
 from trytond.pyson import Eval
 
+from pydicom.uid import generate_uid
+
 if config.getboolean('health_vara', 'filestore', default=True):
     file_id = 'result_report_cache_id'
     store_prefix = config.get('health_vara', 'store_prefix', default=None)
 else:
     file_id = None
     store_prefix = None
+
+
+class ImagingTestRequest(metaclass=PoolMeta):
+    __name__ = 'gnuhealth.imaging.test.request'
+
+    study_instance_uid = fields.Char('Study Instance UID')
+
+    @staticmethod
+    def default_study_instance_uid():
+        return generate_uid(prefix=None)
 
 
 class ImagingTestResult(metaclass=PoolMeta):

--- a/health_imaging.py
+++ b/health_imaging.py
@@ -20,7 +20,8 @@ else:
 class ImagingTestRequest(metaclass=PoolMeta):
     __name__ = 'gnuhealth.imaging.test.request'
 
-    study_instance_uid = fields.Char('Study Instance UID')
+    study_instance_uid = fields.Char('Study Instance UID',
+                                     readonly=True)
     accession_number = fields.Function(fields.Char(
         'Accession Number'), 'get_accession_number')
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ major_version = int(major_version)
 minor_version = int(minor_version)
 name = 'm9s_health_vara'
 download_url = 'https://gitlab.com/m9s/health_vara.git'
-requires = []
+requires = ['pydicom >= 2.3.1, < 3.0']
 
 tryton_base = f'{major_version}.{minor_version}'
 health_base = TRYTON2GH[tryton_base]


### PR DESCRIPTION
Some scanners depend on the RIS to generate a Study Instance UID for an imaging request. This PR extends the model `gnuhealth.imaging.test.request` with a new `Char` field `study_instance_uid`. The default value for this field is an auto-generated random UID. `pydicom` is added as a dependency and is used for generating Study Instance UID values.