### PR TITLE
Add a computed field "Accession Number" to an imaging request. 

### DIFF
--- a/health_imaging.py
+++ b/health_imaging.py
@@ -22,6 +22,14 @@ class ImagingTestRequest(metaclass=PoolMeta):
 
     study_instance_uid = fields.Char('Study Instance UID')
 
+    ACCESSION_NUMBER_PREFIX = config.get(
+        'health_vara', 'accession_number_prefix', default='MXH-')
+    accession_number = fields.Function(fields.Char(
+        'Accession Number'), 'get_accession_number')
+
+    def get_accession_number(self, _name):
+        return self.ACCESSION_NUMBER_PREFIX + str(self.id)
+
     @staticmethod
     def default_study_instance_uid():
         return generate_uid(prefix=None)


### PR DESCRIPTION
This PR adds `accession_number` as a new [computed field](https://docs.tryton.org/projects/server/en/latest/tutorial/module/function_fields.html) to the model `gnuhealth.imaging.test.request`. The prefix added to an accession number is configurable via the section `health_vara` in `trytond.conf`.