### PR TITLE
Override create method for Study Instance UID generation.

### DIFF
--- a/health_imaging.py
+++ b/health_imaging.py
@@ -39,9 +39,12 @@ class ImagingTestRequest(metaclass=PoolMeta):
                     },
                 })
 
-    @staticmethod
-    def default_study_instance_uid():
-        return generate_uid(prefix=None)
+    @classmethod
+    def create(cls, vlist):
+        vlist = [x.copy() for x in vlist]
+        for values in vlist:
+            values['study_instance_uid'] = generate_uid(prefix=None)
+        return super(ImagingTestRequest, cls).create(vlist)
 
     def get_accession_number(self, name):
         return '%s%s' % (_accession_number_prefix, str(self.id))


### PR DESCRIPTION
Tryton seems to be caching default values for fields on a Model. We want a unique Study Instance UID on every imaging request. This PR overrides https://docs.tryton.org/projects/server/en/latest/ref/models.html#trytond.model.ModelStorage.create to auto-generate a Study Instance UID.

