### PR TITLE
Remove `health_orthanc`

### DIFF
--- a/tryton.cfg
+++ b/tryton.cfg
@@ -10,7 +10,6 @@ depends:
     health_icd11
     health_icpm
     health_imaging
-    health_orthanc
     party
     product
 xml:

--- a/view/imaging_test_result_form.xml
+++ b/view/imaging_test_result_form.xml
@@ -2,7 +2,7 @@
 <!-- The COPYRIGHT file at the top level of this repository
 contains the full copyright notices and license terms. -->
 <data>
-    <xpath expr="/form/notebook/page[@id='orthanc_studies_page']" position="before">
+    <xpath expr="/form/notebook/page[@id='images_page']" position="before">
         <page string="Vara Results" id="vara_results_page">
             <label name="image_acquisition_date"/>
             <field name="image_acquisition_date"/>

--- a/view/imaging_test_result_form.xml
+++ b/view/imaging_test_result_form.xml
@@ -2,7 +2,7 @@
 <!-- The COPYRIGHT file at the top level of this repository
 contains the full copyright notices and license terms. -->
 <data>
-    <xpath expr="/form/notebook/page[@id='images_page']" position="before">
+    <xpath expr="/form/notebook/page[1]" position="before">
         <page string="Vara Results" id="vara_results_page">
             <label name="image_acquisition_date"/>
             <field name="image_acquisition_date"/>


### PR DESCRIPTION
https://app.asana.com/0/1204656475814831/1204700406433107/f

This PR removes `health_orthanc` and adjusts the position of the the "Vara Results" page on the Imaging Results form. It was previously before the Orthanc "Study", but this reference does not work when `health_orthanc` is not present. Instead, put the "Vara Page" _before_ the _first_ element (note that XPath is 1 indexed) so the "Vara Results" page is first. See the [Tryton Docs](https://docs.tryton.org/projects/server/en/latest/topics/views/extension.html) for more info.