### PR TITLE
Update vara report for spelling error and wrong assessment calculation

### DIFF
--- a/report/patient_vara_findings.fodt
+++ b/report/patient_vara_findings.fodt
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<office:document xmlns:officeooo="http://openoffice.org/2009/office" xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rpt="http://openoffice.org/2005/report" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:xforms="http://www.w3.org/2002/xforms" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
+<office:document xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:rpt="http://openoffice.org/2005/report" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:officeooo="http://openoffice.org/2009/office" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
  <office:meta>
-    <meta:generator>LibreOffice/7.0.4.2$Linux_X86_64 LibreOffice_project/00$Build-2</meta:generator>
+    <meta:generator>LibreOffice/7.5.4.2$Linux_X86_64 LibreOffice_project/f5df176c80caea84288e6d2ddbbc413e4968a422</meta:generator>
     <meta:creation-date>2008-06-07T15:28:22</meta:creation-date>
     <dc:date>2009-01-10T16:03:33</dc:date>
     <meta:editing-cycles>1</meta:editing-cycles>
@@ -12,132 +12,145 @@
     
     
     
-  <meta:document-statistic meta:table-count="0" meta:image-count="1" meta:object-count="0" meta:page-count="2" meta:paragraph-count="77" meta:word-count="329" meta:character-count="2771" meta:non-whitespace-character-count="2471"/><meta:user-defined meta:name="Info 1"/><meta:user-defined meta:name="Info 2"/><meta:user-defined meta:name="Info 3"/><meta:user-defined meta:name="Info 4"/></office:meta>
+  <meta:document-statistic meta:table-count="0" meta:image-count="1" meta:object-count="0" meta:page-count="2" meta:paragraph-count="77" meta:word-count="328" meta:character-count="2767" meta:non-whitespace-character-count="2472"/><meta:user-defined meta:name="Info 1"/><meta:user-defined meta:name="Info 2"/><meta:user-defined meta:name="Info 3"/><meta:user-defined meta:name="Info 4"/></office:meta>
  <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
-   <config:config-item config:name="ViewAreaTop" config:type="long">3387</config:config-item>
+   <config:config-item config:name="ViewAreaTop" config:type="long">5927</config:config-item>
    <config:config-item config:name="ViewAreaLeft" config:type="long">0</config:config-item>
-   <config:config-item config:name="ViewAreaWidth" config:type="long">49214</config:config-item>
+   <config:config-item config:name="ViewAreaWidth" config:type="long">46939</config:config-item>
    <config:config-item config:name="ViewAreaHeight" config:type="long">22941</config:config-item>
    <config:config-item config:name="ShowRedlineChanges" config:type="boolean">true</config:config-item>
    <config:config-item config:name="InBrowseMode" config:type="boolean">false</config:config-item>
    <config:config-item-map-indexed config:name="Views">
     <config:config-item-map-entry>
      <config:config-item config:name="ViewId" config:type="string">view2</config:config-item>
-     <config:config-item config:name="ViewLeft" config:type="long">26857</config:config-item>
-     <config:config-item config:name="ViewTop" config:type="long">8537</config:config-item>
+     <config:config-item config:name="ViewLeft" config:type="long">3628</config:config-item>
+     <config:config-item config:name="ViewTop" config:type="long">11453</config:config-item>
      <config:config-item config:name="VisibleLeft" config:type="long">0</config:config-item>
-     <config:config-item config:name="VisibleTop" config:type="long">3387</config:config-item>
-     <config:config-item config:name="VisibleRight" config:type="long">49213</config:config-item>
-     <config:config-item config:name="VisibleBottom" config:type="long">26326</config:config-item>
+     <config:config-item config:name="VisibleTop" config:type="long">5927</config:config-item>
+     <config:config-item config:name="VisibleRight" config:type="long">46937</config:config-item>
+     <config:config-item config:name="VisibleBottom" config:type="long">28866</config:config-item>
      <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
      <config:config-item config:name="ViewLayoutColumns" config:type="short">0</config:config-item>
      <config:config-item config:name="ViewLayoutBookMode" config:type="boolean">false</config:config-item>
      <config:config-item config:name="ZoomFactor" config:type="short">100</config:config-item>
      <config:config-item config:name="IsSelectedFrame" config:type="boolean">false</config:config-item>
+     <config:config-item config:name="KeepRatio" config:type="boolean">false</config:config-item>
      <config:config-item config:name="AnchoredTextOverflowLegacy" config:type="boolean">false</config:config-item>
+     <config:config-item config:name="LegacySingleLineFontwork" config:type="boolean">false</config:config-item>
+     <config:config-item config:name="ConnectorUseSnapRect" config:type="boolean">false</config:config-item>
     </config:config-item-map-entry>
    </config:config-item-map-indexed>
   </config:config-item-set>
   <config:config-item-set config:name="ooo:configuration-settings">
-   <config:config-item config:name="PrintProspect" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrintReversed" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrintSingleJobs" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintRightPages" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintProspectRTL" config:type="boolean">false</config:config-item>
    <config:config-item config:name="PrintLeftPages" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="PrintTables" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintPaperFromSetup" config:type="boolean">false</config:config-item>
    <config:config-item config:name="PrintControls" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="PrintPageBackground" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="PrintDrawings" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintProspect" config:type="boolean">false</config:config-item>
    <config:config-item config:name="PrintBlackFonts" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintEmptyPages" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintSingleJobs" config:type="boolean">false</config:config-item>
    <config:config-item config:name="PrintAnnotationMode" config:type="short">0</config:config-item>
-   <config:config-item config:name="PrintTextPlaceholder" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="ProtectFields" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="WordLikeWrapForAsCharFlys" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="AutoFirstLineIndentDisregardLineSpace" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="HeaderSpacingBelowLastPara" config:type="boolean">false</config:config-item>
    <config:config-item config:name="ProtectBookmarks" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="EmptyDbFieldHidesPara" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ContinuousEndnotes" config:type="boolean">false</config:config-item>
    <config:config-item config:name="DisableOffPagePositioning" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintTables" config:type="boolean">true</config:config-item>
    <config:config-item config:name="SubtractFlysAnchoredAtFlys" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="PropLineSpacingShrinksFirstLine" config:type="boolean">false</config:config-item>
    <config:config-item config:name="ApplyParagraphMarkFormatToNumbering" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintFaxName" config:type="string"/>
+   <config:config-item config:name="SurroundTextWrapSmall" config:type="boolean">false</config:config-item>
    <config:config-item config:name="TreatSingleColumnBreakAsPageBreak" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="EmbedSystemFonts" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PropLineSpacingShrinksFirstLine" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="TabOverSpacing" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="TabOverMargin" config:type="boolean">false</config:config-item>
    <config:config-item config:name="EmbedComplexScriptFonts" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="EmbedAsianScriptFonts" config:type="boolean">true</config:config-item>
    <config:config-item config:name="EmbedLatinScriptFonts" config:type="boolean">true</config:config-item>
    <config:config-item config:name="EmbedOnlyUsedFonts" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="ContinuousEndnotes" config:type="boolean">false</config:config-item>
    <config:config-item config:name="EmbedFonts" config:type="boolean">false</config:config-item>
    <config:config-item config:name="ClippedPictures" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="FrameAutowidthWithMorePara" config:type="boolean">false</config:config-item>
    <config:config-item config:name="FloattableNomargins" config:type="boolean">false</config:config-item>
    <config:config-item config:name="UnbreakableNumberings" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="HeaderSpacingBelowLastPara" config:type="boolean">false</config:config-item>
    <config:config-item config:name="AllowPrintJobCancel" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="UseOldPrinterMetrics" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="TabOverMargin" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="TabsRelativeToIndent" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="UseOldNumbering" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="InvertBorderSpacing" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrintPaperFromSetup" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="UpdateFromTemplate" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="CurrentDatabaseCommandType" config:type="int">0</config:config-item>
-   <config:config-item config:name="LinkUpdateMode" config:type="short">1</config:config-item>
-   <config:config-item config:name="AddParaSpacingToTableCells" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="CurrentDatabaseCommand" config:type="string"/>
-   <config:config-item config:name="PrinterIndependentLayout" config:type="string">high-resolution</config:config-item>
-   <config:config-item config:name="ApplyUserData" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrintFaxName" config:type="string"/>
-   <config:config-item config:name="CurrentDatabaseDataSource" config:type="string"/>
-   <config:config-item config:name="ClipAsCharacterAnchoredWriterFlyFrames" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="IsKernAsianPunctuation" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="SaveThumbnail" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="UseFormerTextWrapping" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="AddExternalLeading" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="AddParaTableSpacing" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="StylesNoDefault" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="ChartAutoUpdate" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="PrinterSetup" config:type="base64Binary"/>
-   <config:config-item config:name="AddParaTableSpacingAtStart" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="Rsid" config:type="int">4721315</config:config-item>
-   <config:config-item config:name="EmbeddedDatabaseName" config:type="string"/>
-   <config:config-item config:name="FieldAutoUpdate" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="OutlineLevelYieldsNumbering" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="AlignTabStopPosition" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="CharacterCompressionType" config:type="short">0</config:config-item>
-   <config:config-item config:name="PrinterName" config:type="string"/>
-   <config:config-item config:name="SaveGlobalDocumentLinks" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrinterPaperFromSetup" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="UseFormerLineSpacing" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="AddParaLineSpacingToTableCells" config:type="boolean">false</config:config-item>
    <config:config-item config:name="UseFormerObjectPositioning" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrintGraphics" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="SurroundTextWrapSmall" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="ConsiderTextWrapOnObjPos" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="MsWordCompTrailingBlanks" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="TabAtLeftIndentForParagraphsInList" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrintRightPages" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="IgnoreFirstLineIndentInNumbering" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="RedlineProtectionKey" config:type="base64Binary"/>
-   <config:config-item config:name="DoNotJustifyLinesWithManualBreak" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrintProspectRTL" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrintEmptyPages" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="DoNotResetParaAttrsForNumFont" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="AddFrameOffsets" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="IgnoreTabsAndBlanksForLineCalculation" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="LoadReadonly" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="DoNotCaptureDrawObjsOnPage" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="AddVerticalFrameOffsets" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="UnxForceZeroExtLeading" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="IsLabelDocument" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="TableRowKeep" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="UseOldNumbering" config:type="boolean">false</config:config-item>
    <config:config-item config:name="RsidRoot" config:type="int">204959</config:config-item>
-   <config:config-item config:name="PrintHiddenText" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="ProtectForm" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="MsWordCompMinLineHeightByFly" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="BackgroundParaOverDrawings" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrinterPaperFromSetup" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="CurrentDatabaseDataSource" config:type="string"/>
+   <config:config-item config:name="UpdateFromTemplate" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="AddFrameOffsets" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="LoadReadonly" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="Rsid" config:type="int">4877520</config:config-item>
+   <config:config-item config:name="FootnoteInColumnToPageEnd" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="ProtectFields" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="SaveGlobalDocumentLinks" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ClipAsCharacterAnchoredWriterFlyFrames" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="LinkUpdateMode" config:type="short">1</config:config-item>
+   <config:config-item config:name="AddExternalLeading" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintGraphics" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="EmbedSystemFonts" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="IsLabelDocument" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="AddParaLineSpacingToTableCells" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="UseFormerTextWrapping" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="HyphenateURLs" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="AddParaTableSpacingAtStart" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="TabsRelativeToIndent" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="FieldAutoUpdate" config:type="boolean">true</config:config-item>
    <config:config-item config:name="SaveVersionOnClose" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="MathBaselineAlignment" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ChartAutoUpdate" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="ImagePreferredDPI" config:type="int">0</config:config-item>
+   <config:config-item config:name="PrinterSetup" config:type="base64Binary"/>
    <config:config-item config:name="SmallCapsPercentage66" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="CollapseEmptyCellPara" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="AlignTabStopPosition" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="DropCapPunctuation" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="MathBaselineAlignment" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrinterName" config:type="string"/>
+   <config:config-item config:name="CharacterCompressionType" config:type="short">0</config:config-item>
+   <config:config-item config:name="AddParaTableSpacing" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="DoNotJustifyLinesWithManualBreak" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintHiddenText" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="IsKernAsianPunctuation" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrinterIndependentLayout" config:type="string">high-resolution</config:config-item>
    <config:config-item config:name="TabOverflow" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="AddParaSpacingToTableCells" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="AddVerticalFrameOffsets" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="TabAtLeftIndentForParagraphsInList" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ApplyUserData" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="MsWordCompMinLineHeightByFly" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintTextPlaceholder" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="IgnoreFirstLineIndentInNumbering" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="UseFormerLineSpacing" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintPageBackground" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="RedlineProtectionKey" config:type="base64Binary"/>
+   <config:config-item config:name="EmbedAsianScriptFonts" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="BackgroundParaOverDrawings" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="SaveThumbnail" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ConsiderTextWrapOnObjPos" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="EmbeddedDatabaseName" config:type="string"/>
+   <config:config-item config:name="ProtectForm" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="DoNotResetParaAttrsForNumFont" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="MsWordCompTrailingBlanks" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="EmptyDbFieldHidesPara" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="TableRowKeep" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="NoNumberingShowFollowBy" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="InvertBorderSpacing" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="IgnoreTabsAndBlanksForLineCalculation" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="DoNotCaptureDrawObjsOnPage" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="GutterAtTop" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="StylesNoDefault" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="UnxForceZeroExtLeading" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintReversed" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="UseOldPrinterMetrics" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="CurrentDatabaseCommandType" config:type="int">0</config:config-item>
+   <config:config-item config:name="PrintDrawings" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="OutlineLevelYieldsNumbering" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="CurrentDatabaseCommand" config:type="string"/>
+   <config:config-item config:name="CollapseEmptyCellPara" config:type="boolean">true</config:config-item>
   </config:config-item-set>
  </office:settings>
  <office:scripts>
@@ -148,20 +161,20 @@
   </office:script>
  </office:scripts>
  <office:font-face-decls>
-  <style:font-face style:name="Arial1" svg:font-family="Arial"/>
+  <style:font-face style:name="Andale Sans UI" svg:font-family="&apos;Andale Sans UI&apos;" style:font-family-generic="system" style:font-pitch="variable"/>
+  <style:font-face style:name="Arial" svg:font-family="Arial"/>
+  <style:font-face style:name="Arial1" svg:font-family="Arial" style:font-family-generic="swiss"/>
+  <style:font-face style:name="Arial2" svg:font-family="Arial" style:font-family-generic="swiss" style:font-pitch="variable"/>
+  <style:font-face style:name="DejaVu Sans" svg:font-family="&apos;DejaVu Sans&apos;" style:font-family-generic="system" style:font-pitch="variable"/>
+  <style:font-face style:name="Liberation Mono" svg:font-family="&apos;Liberation Mono&apos;" style:font-family-generic="modern" style:font-pitch="fixed"/>
+  <style:font-face style:name="Liberation Sans" svg:font-family="&apos;Liberation Sans&apos;" style:font-adornments="Regular" style:font-family-generic="swiss" style:font-pitch="variable"/>
+  <style:font-face style:name="Liberation Serif" svg:font-family="&apos;Liberation Serif&apos;" style:font-family-generic="roman" style:font-pitch="variable"/>
+  <style:font-face style:name="Liberation Serif1" svg:font-family="&apos;Liberation Serif&apos;" style:font-adornments="Bold" style:font-family-generic="roman" style:font-pitch="variable"/>
+  <style:font-face style:name="Liberation Serif2" svg:font-family="&apos;Liberation Serif&apos;" style:font-adornments="Regular" style:font-family-generic="roman" style:font-pitch="variable"/>
   <style:font-face style:name="Monaco" svg:font-family="Monaco, Menlo, Consolas, &apos;Courier New&apos;, monospace"/>
   <style:font-face style:name="StarSymbol" svg:font-family="StarSymbol"/>
-  <style:font-face style:name="Arial" svg:font-family="Arial" style:font-family-generic="swiss"/>
-  <style:font-face style:name="mononoki" svg:font-family="mononoki" style:font-pitch="fixed"/>
-  <style:font-face style:name="Liberation Mono" svg:font-family="&apos;Liberation Mono&apos;" style:font-family-generic="modern" style:font-pitch="fixed"/>
-  <style:font-face style:name="Liberation Serif2" svg:font-family="&apos;Liberation Serif&apos;" style:font-family-generic="roman" style:font-pitch="variable"/>
-  <style:font-face style:name="Liberation Serif1" svg:font-family="&apos;Liberation Serif&apos;" style:font-adornments="Bold" style:font-family-generic="roman" style:font-pitch="variable"/>
-  <style:font-face style:name="Liberation Serif" svg:font-family="&apos;Liberation Serif&apos;" style:font-adornments="Regular" style:font-family-generic="roman" style:font-pitch="variable"/>
   <style:font-face style:name="Thorndale AMT" svg:font-family="&apos;Thorndale AMT&apos;" style:font-family-generic="roman" style:font-pitch="variable"/>
-  <style:font-face style:name="Arial2" svg:font-family="Arial" style:font-family-generic="swiss" style:font-pitch="variable"/>
-  <style:font-face style:name="Liberation Sans" svg:font-family="&apos;Liberation Sans&apos;" style:font-adornments="Regular" style:font-family-generic="swiss" style:font-pitch="variable"/>
-  <style:font-face style:name="Andale Sans UI" svg:font-family="&apos;Andale Sans UI&apos;" style:font-family-generic="system" style:font-pitch="variable"/>
-  <style:font-face style:name="DejaVu Sans" svg:font-family="&apos;DejaVu Sans&apos;" style:font-family-generic="system" style:font-pitch="variable"/>
+  <style:font-face style:name="mononoki" svg:font-family="mononoki" style:font-pitch="fixed"/>
  </office:font-face-decls>
  <office:styles>
   <draw:gradient draw:name="Gradient_20_2" draw:display-name="Gradient 2" draw:style="linear" draw:start-color="#000000" draw:end-color="#ffffff" draw:start-intensity="100%" draw:end-intensity="100%" draw:angle="0deg" draw:border="0%"/>
@@ -169,17 +182,17 @@
   <draw:gradient draw:name="Gradient_20_4" draw:display-name="Gradient 4" draw:style="linear" draw:start-color="#000000" draw:end-color="#ffffff" draw:start-intensity="100%" draw:end-intensity="100%" draw:angle="0deg" draw:border="0%"/>
   <draw:gradient draw:name="Gradient_20_5" draw:display-name="Gradient 5" draw:style="linear" draw:start-color="#000000" draw:end-color="#ffffff" draw:start-intensity="100%" draw:end-intensity="100%" draw:angle="0deg" draw:border="0%"/>
   <draw:gradient draw:name="gradient" draw:style="linear" draw:start-color="#000000" draw:end-color="#ffffff" draw:start-intensity="100%" draw:end-intensity="100%" draw:angle="0deg" draw:border="0%"/>
-  <draw:hatch draw:name="hatch" draw:style="single" draw:color="#3465a4" draw:distance="0.0079in" draw:rotation="0"/>
+  <draw:hatch draw:name="hatch" draw:style="single" draw:color="#3465a4" draw:distance="0.02cm" draw:rotation="0"/>
   <style:default-style style:family="graphic">
-   <style:graphic-properties svg:stroke-color="#000000" draw:fill-color="#99ccff" fo:wrap-option="no-wrap" draw:shadow-offset-x="0.1181in" draw:shadow-offset-y="0.1181in" draw:start-line-spacing-horizontal="0.1114in" draw:start-line-spacing-vertical="0.1114in" draw:end-line-spacing-horizontal="0.1114in" draw:end-line-spacing-vertical="0.1114in" style:flow-with-text="false"/>
-   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" style:writing-mode="lr-tb" style:font-independent-line-spacing="false">
+   <style:graphic-properties svg:stroke-color="#000000" draw:fill-color="#99ccff" fo:wrap-option="no-wrap" draw:shadow-offset-x="0.3cm" draw:shadow-offset-y="0.3cm" draw:start-line-spacing-horizontal="0.283cm" draw:start-line-spacing-vertical="0.283cm" draw:end-line-spacing-horizontal="0.283cm" draw:end-line-spacing-vertical="0.283cm" style:writing-mode="lr-tb" style:flow-with-text="false"/>
+   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" style:font-independent-line-spacing="false">
     <style:tab-stops/>
    </style:paragraph-properties>
-   <style:text-properties style:use-window-font-color="true" loext:opacity="0%" style:font-name="Thorndale AMT" fo:font-size="12pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="Andale Sans UI" style:font-size-asian="10.5pt" style:language-asian="zxx" style:country-asian="none" style:font-name-complex="Andale Sans UI" style:font-size-complex="12pt" style:language-complex="zxx" style:country-complex="none"/>
+   <style:text-properties style:use-window-font-color="true" loext:opacity="0%" loext:color-lum-mod="100%" loext:color-lum-off="0%" style:font-name="Thorndale AMT" fo:font-size="12pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="Andale Sans UI" style:font-size-asian="10.5pt" style:language-asian="zxx" style:country-asian="none" style:font-name-complex="Andale Sans UI" style:font-size-complex="12pt" style:language-complex="zxx" style:country-complex="none"/>
   </style:default-style>
   <style:default-style style:family="paragraph">
-   <style:paragraph-properties fo:hyphenation-ladder-count="no-limit" style:text-autospace="ideograph-alpha" style:punctuation-wrap="hanging" style:line-break="strict" style:tab-stop-distance="0.4925in" style:writing-mode="lr-tb"/>
-   <style:text-properties style:use-window-font-color="true" loext:opacity="0%" style:font-name="Thorndale AMT" fo:font-size="12pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="Andale Sans UI" style:font-size-asian="10.5pt" style:language-asian="zxx" style:country-asian="none" style:font-name-complex="Andale Sans UI" style:font-size-complex="12pt" style:language-complex="zxx" style:country-complex="none" fo:hyphenate="false" fo:hyphenation-remain-char-count="2" fo:hyphenation-push-char-count="2" loext:hyphenation-no-caps="false"/>
+   <style:paragraph-properties fo:hyphenation-ladder-count="no-limit" style:text-autospace="ideograph-alpha" style:punctuation-wrap="hanging" style:line-break="strict" style:tab-stop-distance="1.251cm" style:writing-mode="lr-tb"/>
+   <style:text-properties style:use-window-font-color="true" loext:opacity="0%" style:font-name="Thorndale AMT" fo:font-size="12pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="Andale Sans UI" style:font-size-asian="10.5pt" style:language-asian="zxx" style:country-asian="none" style:font-name-complex="Andale Sans UI" style:font-size-complex="12pt" style:language-complex="zxx" style:country-complex="none" fo:hyphenate="false" fo:hyphenation-remain-char-count="2" fo:hyphenation-push-char-count="2" loext:hyphenation-no-caps="false" loext:hyphenation-no-last-word="false" loext:hyphenation-word-char-count="5" loext:hyphenation-zone="no-limit"/>
   </style:default-style>
   <style:default-style style:family="table">
    <style:table-properties table:border-model="collapsing"/>
@@ -191,18 +204,18 @@
    <style:text-properties style:font-name="Liberation Sans" fo:font-family="&apos;Liberation Sans&apos;" style:font-style-name="Regular" style:font-family-generic="swiss" style:font-pitch="variable" style:font-size-asian="10.5pt"/>
   </style:style>
   <style:style style:name="Heading" style:family="paragraph" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="text">
-   <style:paragraph-properties fo:margin-top="0.1665in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:keep-with-next="always"/>
-   <style:text-properties style:font-name="Liberation Serif" fo:font-family="&apos;Liberation Serif&apos;" style:font-style-name="Regular" style:font-family-generic="roman" style:font-pitch="variable" fo:font-size="16pt" style:font-name-asian="DejaVu Sans" style:font-family-asian="&apos;DejaVu Sans&apos;" style:font-family-generic-asian="system" style:font-pitch-asian="variable" style:font-size-asian="14pt" style:font-name-complex="DejaVu Sans" style:font-family-complex="&apos;DejaVu Sans&apos;" style:font-family-generic-complex="system" style:font-pitch-complex="variable" style:font-size-complex="14pt"/>
+   <style:paragraph-properties fo:margin-top="0.423cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:keep-with-next="always"/>
+   <style:text-properties style:font-name="Liberation Serif2" fo:font-family="&apos;Liberation Serif&apos;" style:font-style-name="Regular" style:font-family-generic="roman" style:font-pitch="variable" fo:font-size="16pt" style:font-name-asian="DejaVu Sans" style:font-family-asian="&apos;DejaVu Sans&apos;" style:font-family-generic-asian="system" style:font-pitch-asian="variable" style:font-size-asian="14pt" style:font-name-complex="DejaVu Sans" style:font-family-complex="&apos;DejaVu Sans&apos;" style:font-family-generic-complex="system" style:font-pitch-complex="variable" style:font-size-complex="14pt"/>
   </style:style>
   <style:style style:name="Text_20_body" style:display-name="Text body" style:family="paragraph" style:parent-style-name="Standard" style:class="text">
-   <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false"/>
+   <style:paragraph-properties fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false"/>
    <style:text-properties style:font-name="Liberation Sans" fo:font-family="&apos;Liberation Sans&apos;" style:font-style-name="Regular" style:font-family-generic="swiss" style:font-pitch="variable" style:font-size-asian="10.5pt"/>
   </style:style>
   <style:style style:name="List" style:family="paragraph" style:parent-style-name="Text_20_body" style:class="list">
    <style:text-properties style:font-size-asian="12pt"/>
   </style:style>
   <style:style style:name="Caption" style:family="paragraph" style:parent-style-name="Standard" style:class="extra">
-   <style:paragraph-properties fo:margin-top="0.0835in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" text:number-lines="false" text:line-number="0"/>
+   <style:paragraph-properties fo:margin-top="0.212cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" text:number-lines="false" text:line-number="0"/>
    <style:text-properties fo:font-size="12pt" fo:font-style="italic" style:font-size-asian="12pt" style:font-style-asian="italic" style:font-size-complex="12pt" style:font-style-complex="italic"/>
   </style:style>
   <style:style style:name="Index" style:family="paragraph" style:parent-style-name="Standard" style:class="index">
@@ -226,16 +239,16 @@
   <style:style style:name="Header_20_and_20_Footer" style:display-name="Header and Footer" style:family="paragraph" style:parent-style-name="Standard" style:class="extra">
    <style:paragraph-properties text:number-lines="false" text:line-number="0">
     <style:tab-stops>
-     <style:tab-stop style:position="3.3465in" style:type="center"/>
-     <style:tab-stop style:position="6.6929in" style:type="right"/>
+     <style:tab-stop style:position="8.5cm" style:type="center"/>
+     <style:tab-stop style:position="17cm" style:type="right"/>
     </style:tab-stops>
    </style:paragraph-properties>
   </style:style>
   <style:style style:name="Header" style:family="paragraph" style:parent-style-name="Standard" style:class="extra">
    <style:paragraph-properties text:number-lines="false" text:line-number="0">
     <style:tab-stops>
-     <style:tab-stop style:position="3.4626in" style:type="center"/>
-     <style:tab-stop style:position="6.9252in" style:type="right"/>
+     <style:tab-stop style:position="8.795cm" style:type="center"/>
+     <style:tab-stop style:position="17.59cm" style:type="right"/>
     </style:tab-stops>
    </style:paragraph-properties>
    <style:text-properties fo:font-size="9pt" style:font-size-asian="10.5pt"/>
@@ -243,8 +256,8 @@
   <style:style style:name="Footer" style:family="paragraph" style:parent-style-name="Standard" style:class="extra">
    <style:paragraph-properties text:number-lines="false" text:line-number="0">
     <style:tab-stops>
-     <style:tab-stop style:position="3.4626in" style:type="center"/>
-     <style:tab-stop style:position="6.9252in" style:type="right"/>
+     <style:tab-stop style:position="8.795cm" style:type="center"/>
+     <style:tab-stop style:position="17.59cm" style:type="right"/>
     </style:tab-stops>
    </style:paragraph-properties>
    <style:text-properties fo:font-size="9pt" style:font-size-asian="10.5pt"/>
@@ -253,22 +266,22 @@
    <style:text-properties fo:font-size="14pt" fo:font-weight="bold" style:font-size-asian="14pt" style:font-weight-asian="bold" style:font-size-complex="14pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="Text_20_body_20_indent" style:display-name="Text body indent" style:family="paragraph" style:parent-style-name="Text_20_body" style:class="text">
-   <style:paragraph-properties fo:margin-left="0.1965in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
+   <style:paragraph-properties fo:margin-left="0.499cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
   </style:style>
   <style:style style:name="Text" style:family="paragraph" style:parent-style-name="Caption" style:class="extra"/>
   <style:style style:name="Quotations" style:family="paragraph" style:parent-style-name="Standard" style:class="html">
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0.3937in" fo:margin-top="0in" fo:margin-bottom="0.1965in" style:contextual-spacing="false" fo:text-indent="0in" style:auto-text-indent="false"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="1cm" fo:margin-top="0cm" fo:margin-bottom="0.499cm" style:contextual-spacing="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
   </style:style>
   <style:style style:name="Title" style:family="paragraph" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:class="chapter">
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties fo:font-size="28pt" fo:font-weight="bold" style:font-size-asian="28pt" style:font-weight-asian="bold" style:font-size-complex="28pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="Subtitle" style:family="paragraph" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:class="chapter">
-   <style:paragraph-properties fo:margin-top="0.0417in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false"/>
+   <style:paragraph-properties fo:margin-top="0.106cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties fo:font-size="18pt" style:font-size-asian="18pt" style:font-size-complex="18pt"/>
   </style:style>
   <style:style style:name="Preformatted_20_Text" style:display-name="Preformatted Text" style:family="paragraph" style:parent-style-name="Standard" style:class="html">
-   <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false"/>
+   <style:paragraph-properties fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false"/>
    <style:text-properties style:font-name="Liberation Mono" fo:font-family="&apos;Liberation Mono&apos;" style:font-family-generic="modern" style:font-pitch="fixed" fo:font-size="10pt" style:font-name-asian="Liberation Mono" style:font-family-asian="&apos;Liberation Mono&apos;" style:font-family-generic-asian="modern" style:font-pitch-asian="fixed" style:font-size-asian="10pt" style:font-name-complex="Liberation Mono" style:font-family-complex="&apos;Liberation Mono&apos;" style:font-family-generic-complex="modern" style:font-pitch-complex="fixed" style:font-size-complex="10pt"/>
   </style:style>
   <style:style style:name="Placeholder" style:family="text">
@@ -281,43 +294,43 @@
    <style:text-properties fo:color="#000080" loext:opacity="100%" fo:language="zxx" fo:country="none" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" style:language-asian="zxx" style:country-asian="none" style:language-complex="zxx" style:country-complex="none"/>
   </style:style>
   <style:style style:name="Graphics" style:family="graphic">
-   <style:graphic-properties text:anchor-type="paragraph" svg:x="0in" svg:y="0in" style:wrap="dynamic" style:number-wrapped-paragraphs="no-limit" style:wrap-contour="false" style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph"/>
+   <style:graphic-properties text:anchor-type="paragraph" svg:x="0cm" svg:y="0cm" style:wrap="dynamic" style:number-wrapped-paragraphs="no-limit" style:wrap-contour="false" style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph"/>
   </style:style>
   <text:outline-style style:name="Outline">
-   <text:outline-level-style text:level="1" style:num-format="">
-    <style:list-level-properties text:min-label-distance="0.15in"/>
+   <text:outline-level-style text:level="1" loext:num-list-format="%1%" style:num-format="">
+    <style:list-level-properties text:min-label-distance="0.381cm"/>
    </text:outline-level-style>
-   <text:outline-level-style text:level="2" style:num-format="">
-    <style:list-level-properties text:min-label-distance="0.15in"/>
+   <text:outline-level-style text:level="2" loext:num-list-format="%2%" style:num-format="">
+    <style:list-level-properties text:min-label-distance="0.381cm"/>
    </text:outline-level-style>
-   <text:outline-level-style text:level="3" style:num-format="">
-    <style:list-level-properties text:min-label-distance="0.15in"/>
+   <text:outline-level-style text:level="3" loext:num-list-format="%3%" style:num-format="">
+    <style:list-level-properties text:min-label-distance="0.381cm"/>
    </text:outline-level-style>
-   <text:outline-level-style text:level="4" style:num-format="">
-    <style:list-level-properties text:min-label-distance="0.15in"/>
+   <text:outline-level-style text:level="4" loext:num-list-format="%4%" style:num-format="">
+    <style:list-level-properties text:min-label-distance="0.381cm"/>
    </text:outline-level-style>
-   <text:outline-level-style text:level="5" style:num-format="">
-    <style:list-level-properties text:min-label-distance="0.15in"/>
+   <text:outline-level-style text:level="5" loext:num-list-format="%5%" style:num-format="">
+    <style:list-level-properties text:min-label-distance="0.381cm"/>
    </text:outline-level-style>
-   <text:outline-level-style text:level="6" style:num-format="">
-    <style:list-level-properties text:min-label-distance="0.15in"/>
+   <text:outline-level-style text:level="6" loext:num-list-format="%6%" style:num-format="">
+    <style:list-level-properties text:min-label-distance="0.381cm"/>
    </text:outline-level-style>
-   <text:outline-level-style text:level="7" style:num-format="">
-    <style:list-level-properties text:min-label-distance="0.15in"/>
+   <text:outline-level-style text:level="7" loext:num-list-format="%7%" style:num-format="">
+    <style:list-level-properties text:min-label-distance="0.381cm"/>
    </text:outline-level-style>
-   <text:outline-level-style text:level="8" style:num-format="">
-    <style:list-level-properties text:min-label-distance="0.15in"/>
+   <text:outline-level-style text:level="8" loext:num-list-format="%8%" style:num-format="">
+    <style:list-level-properties text:min-label-distance="0.381cm"/>
    </text:outline-level-style>
-   <text:outline-level-style text:level="9" style:num-format="">
-    <style:list-level-properties text:min-label-distance="0.15in"/>
+   <text:outline-level-style text:level="9" loext:num-list-format="%9%" style:num-format="">
+    <style:list-level-properties text:min-label-distance="0.381cm"/>
    </text:outline-level-style>
-   <text:outline-level-style text:level="10" style:num-format="">
-    <style:list-level-properties text:min-label-distance="0.15in"/>
+   <text:outline-level-style text:level="10" loext:num-list-format="%10%" style:num-format="">
+    <style:list-level-properties text:min-label-distance="0.381cm"/>
    </text:outline-level-style>
   </text:outline-style>
   <text:notes-configuration text:note-class="footnote" style:num-format="1" text:start-value="0" text:footnotes-position="page" text:start-numbering-at="document"/>
   <text:notes-configuration text:note-class="endnote" style:num-format="i" text:start-value="0"/>
-  <text:linenumbering-configuration text:number-lines="false" text:offset="0.1965in" style:num-format="1" text:number-position="left" text:increment="5"/>
+  <text:linenumbering-configuration text:number-lines="false" text:offset="0.499cm" style:num-format="1" text:number-position="left" text:increment="5"/>
  </office:styles>
  <office:automatic-styles>
   <style:style style:name="P1" style:family="paragraph" style:parent-style-name="Header">
@@ -336,1488 +349,1685 @@
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties officeooo:paragraph-rsid="00066dfa"/>
   </style:style>
-  <style:style style:name="P5" style:family="paragraph" style:parent-style-name="Header">
-   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
-   <style:text-properties fo:font-size="12pt" officeooo:paragraph-rsid="00066dfa" style:font-size-asian="12pt" style:font-size-complex="12pt"/>
-  </style:style>
-  <style:style style:name="P6" style:family="paragraph" style:parent-style-name="Header">
-   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
-   <style:text-properties officeooo:paragraph-rsid="003bb962"/>
-  </style:style>
-  <style:style style:name="P7" style:family="paragraph" style:parent-style-name="Header">
-   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
-   <style:text-properties fo:font-weight="bold" officeooo:paragraph-rsid="003bb962" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P8" style:family="paragraph" style:parent-style-name="Header">
-   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
-   <style:text-properties fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="003bb962" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P9" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
-   <style:text-properties fo:font-size="13pt" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001b5069" style:font-size-asian="13pt" style:font-weight-asian="bold" style:font-size-complex="13pt"/>
-  </style:style>
-  <style:style style:name="P10" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
-   <style:text-properties officeooo:paragraph-rsid="001b5069"/>
-  </style:style>
-  <style:style style:name="P11" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties>
-    <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P12" style:family="paragraph" style:parent-style-name="Standard">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P13" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties>
-    <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="001cb086" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P14" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties>
-    <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P15" style:family="paragraph" style:parent-style-name="Standard">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:rsid="001cb086" officeooo:paragraph-rsid="001cb086" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P16" style:family="paragraph" style:parent-style-name="Standard">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="001cb179" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P17" style:family="paragraph" style:parent-style-name="Standard">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="0021def5" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P18" style:family="paragraph" style:parent-style-name="Standard">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="00231ad9" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P19" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties>
-    <style:tab-stops>
-     <style:tab-stop style:position="1.9689in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="00232940" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P20" style:family="paragraph" style:parent-style-name="Standard">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="003086e6" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P21" style:family="paragraph" style:parent-style-name="Standard">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" fo:font-weight="bold" officeooo:paragraph-rsid="003086e6" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P22" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties>
-    <style:tab-stops>
-     <style:tab-stop style:position="1.9689in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" fo:font-weight="bold" officeooo:rsid="003086e6" officeooo:paragraph-rsid="0033aaea" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P23" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties>
-    <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties officeooo:paragraph-rsid="001b5069"/>
-  </style:style>
-  <style:style style:name="P24" style:family="paragraph" style:parent-style-name="Standard">
-   <style:text-properties officeooo:paragraph-rsid="001cb179"/>
-  </style:style>
-  <style:style style:name="P25" style:family="paragraph" style:parent-style-name="Standard">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb086" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P26" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties>
-    <style:tab-stops>
-     <style:tab-stop style:position="1.9689in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P27" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties>
-    <style:tab-stops>
-     <style:tab-stop style:position="1.9689in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" officeooo:paragraph-rsid="0033aaea" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P28" style:family="paragraph" style:parent-style-name="Standard">
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P29" style:family="paragraph" style:parent-style-name="Standard">
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="003086e6" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P30" style:family="paragraph" style:parent-style-name="Footer">
+  <style:style style:name="P5" style:family="paragraph" style:parent-style-name="Footer">
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties officeooo:paragraph-rsid="00066dfa"/>
   </style:style>
-  <style:style style:name="P31" style:family="paragraph" style:parent-style-name="Footer">
+  <style:style style:name="P6" style:family="paragraph" style:parent-style-name="Standard">
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
-   <style:text-properties style:font-name="Arial" officeooo:paragraph-rsid="00066dfa"/>
-  </style:style>
-  <style:style style:name="P32" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
-  </style:style>
-  <style:style style:name="P33" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:text-align="end" style:justify-single-word="false"/>
-  </style:style>
-  <style:style style:name="P34" style:family="paragraph" style:parent-style-name="Table_20_Contents">
-   <style:paragraph-properties fo:text-align="end" style:justify-single-word="false"/>
-   <style:text-properties officeooo:paragraph-rsid="0008048e"/>
-  </style:style>
-  <style:style style:name="P35" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties officeooo:paragraph-rsid="0029fe83"/>
-  </style:style>
-  <style:style style:name="P36" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P37" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="0029fe83" officeooo:paragraph-rsid="0029fe83" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P38" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83"/>
-  </style:style>
-  <style:style style:name="P39" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="11pt" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P40" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="11pt" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P41" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" fo:font-style="italic" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="11pt" style:font-style-asian="italic" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-style-complex="italic" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P42" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" fo:font-style="italic" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003e0772" style:font-size-asian="11pt" style:font-style-asian="italic" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-style-complex="italic" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P43" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P44" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003e0772" style:font-size-asian="9pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P45" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="004151b0" style:font-size-asian="9pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P46" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P47" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0037be7b" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P48" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0029fe83" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P49" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P50" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P51" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P52" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P53" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="003086e6" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P54" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent"/>
-  </style:style>
-  <style:style style:name="P55" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent"/>
-  </style:style>
-  <style:style style:name="P56" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P57" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P58" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P59" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002d4b65" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent"/>
-  </style:style>
-  <style:style style:name="P60" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P61" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="003086e6" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P62" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P63" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P64" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P65" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P66" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003bb962" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P67" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P68" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003bb962" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P69" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00466870" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P70" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="004151b0" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P71" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83"/>
-  </style:style>
-  <style:style style:name="P72" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0037be7b"/>
-  </style:style>
-  <style:style style:name="P73" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003dbced" style:font-size-asian="11pt" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P74" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003dbced" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P75" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P76" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0037be7b" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P77" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P78" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003dbced" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P79" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P80" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="003dbced" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P81" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="0043a2e0" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P82" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties officeooo:paragraph-rsid="0029fe83"/>
-  </style:style>
-  <style:style style:name="P83" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties officeooo:paragraph-rsid="001ea66e"/>
-  </style:style>
-  <style:style style:name="P84" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties officeooo:paragraph-rsid="00466870"/>
-  </style:style>
-  <style:style style:name="P85" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="001ea66e" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P86" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P87" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent"/>
-  </style:style>
-  <style:style style:name="P88" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent"/>
-  </style:style>
-  <style:style style:name="P89" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent"/>
-  </style:style>
-  <style:style style:name="P90" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P91" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00466870" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P92" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P93" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P94" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P95" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0037be7b" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P96" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P97" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:line-height="0.1201in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0043a2e0" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P98" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:line-height="0.1201in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="004236e2" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P99" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P100" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P101" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:line-height="0.1201in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P102" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83"/>
-  </style:style>
-  <style:style style:name="P103" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:break-before="page" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent"/>
-  </style:style>
-  <style:style style:name="P104" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties officeooo:paragraph-rsid="0030f177"/>
-  </style:style>
-  <style:style style:name="P105" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="00200e99" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P106" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="003086e6" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P107" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:font-size-asian="11pt" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P108" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb179" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P109" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P110" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P111" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="00200e99" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P112" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="00231ad9" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P113" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P114" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P115" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P116" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002d4b65" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P117" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002d4b65" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P118" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:paragraph-rsid="001cb179" style:text-blinking="false" fo:background-color="transparent"/>
-  </style:style>
-  <style:style style:name="P119" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002d4b65" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent"/>
-  </style:style>
-  <style:style style:name="P120" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002d4b65" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent"/>
-  </style:style>
-  <style:style style:name="P121" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P122" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P123" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P124" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P125" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P126" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P127" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P128" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P129" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P130" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P131" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P132" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0042065a" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P133" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" officeooo:paragraph-rsid="0030f177"/>
-  </style:style>
-  <style:style style:name="P134" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="003b4dc5" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P135" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P136" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0042065a" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P137" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="004236e2" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P138" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:line-height="0.1201in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0043a2e0" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P139" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0037be7b" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P140" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
-  </style:style>
-  <style:style style:name="P141" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent">
-    <style:tab-stops>
-     <style:tab-stop style:position="1.9689in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0033aaea" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P142" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent">
-    <style:tab-stops>
-     <style:tab-stop style:position="1.9689in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0037be7b" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P143" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:font-size-asian="11pt" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P144" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0037be7b" officeooo:paragraph-rsid="003a7a58" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P145" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P146" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" officeooo:rsid="0037be7b" officeooo:paragraph-rsid="00393dbe" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P147" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P148" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent">
-    <style:tab-stops>
-     <style:tab-stop style:position="1.9689in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0037be7b" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P149" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent">
-    <style:tab-stops>
-     <style:tab-stop style:position="1.9689in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0037be7b" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P150" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P151" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P152" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P153" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P154" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003bb962" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P155" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P156" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P157" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P158" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="0033aaea" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P159" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
-    <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties officeooo:paragraph-rsid="0029fe83"/>
-  </style:style>
-  <style:style style:name="P160" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
    <style:text-properties officeooo:paragraph-rsid="001b5069"/>
   </style:style>
-  <style:style style:name="P161" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:break-before="page"/>
-   <style:text-properties fo:font-size="6pt" officeooo:paragraph-rsid="0011a01d" style:font-size-asian="5.25pt" style:font-size-complex="6pt"/>
+  <style:style style:name="P7" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
   </style:style>
-  <style:style style:name="P162" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent"/>
+  <style:style style:name="P8" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties fo:font-size="13pt" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001b5069" style:font-size-asian="13pt" style:font-weight-asian="bold" style:font-size-complex="13pt"/>
   </style:style>
-  <style:style style:name="P163" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  <style:style style:name="P9" style:family="paragraph" style:parent-style-name="Header">
+   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
+   <style:text-properties fo:font-size="12pt" officeooo:paragraph-rsid="00066dfa" style:font-size-asian="12pt" style:font-size-complex="12pt"/>
   </style:style>
-  <style:style style:name="P164" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  <style:style style:name="P10" style:family="paragraph" style:parent-style-name="Header">
+   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
+   <style:text-properties officeooo:paragraph-rsid="003bb962"/>
   </style:style>
-  <style:style style:name="P165" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:text-underline-style="none" officeooo:paragraph-rsid="002d4b65"/>
-  </style:style>
-  <style:style style:name="P166" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:text-underline-style="none" officeooo:paragraph-rsid="003086e6"/>
-  </style:style>
-  <style:style style:name="P167" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:font-name="Liberation Serif2"/>
-  </style:style>
-  <style:style style:name="P168" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:font-name="Liberation Serif2"/>
-  </style:style>
-  <style:style style:name="P169" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:font-name="Liberation Serif2" officeooo:paragraph-rsid="0014b27d"/>
-  </style:style>
-  <style:style style:name="P170" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false"/>
+  <style:style style:name="P11" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
    <style:text-properties officeooo:paragraph-rsid="0029fe83"/>
   </style:style>
-  <style:style style:name="P171" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties officeooo:paragraph-rsid="001ea66e"/>
-  </style:style>
-  <style:style style:name="P172" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties officeooo:paragraph-rsid="001cb179"/>
-  </style:style>
-  <style:style style:name="P173" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P174" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb179" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P175" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001ea66e" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P176" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P177" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:text-underline-style="none" officeooo:paragraph-rsid="001cb179"/>
-  </style:style>
-  <style:style style:name="P178" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties officeooo:paragraph-rsid="001ea66e"/>
-  </style:style>
-  <style:style style:name="P179" style:family="paragraph" style:parent-style-name="Text_20_body">
+  <style:style style:name="P12" style:family="paragraph" style:parent-style-name="Text_20_body">
    <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties officeooo:paragraph-rsid="001ea66e"/>
-  </style:style>
-  <style:style style:name="P180" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties officeooo:paragraph-rsid="001cb179"/>
-  </style:style>
-  <style:style style:name="P181" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" officeooo:paragraph-rsid="001cb179" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P182" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" officeooo:paragraph-rsid="0021def5" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P183" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P184" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb179" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P185" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P186" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P187" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001ea66e" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P188" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001ea66e" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P189" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="00232940" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P190" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="00231ad9" officeooo:paragraph-rsid="00231ad9" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P191" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="00231ad9" officeooo:paragraph-rsid="00231ad9" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P192" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties officeooo:paragraph-rsid="001ea66e"/>
-  </style:style>
-  <style:style style:name="P193" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties officeooo:paragraph-rsid="0021def5"/>
-  </style:style>
-  <style:style style:name="P194" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties officeooo:paragraph-rsid="001cb179"/>
-  </style:style>
-  <style:style style:name="P195" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P196" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P197" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb179" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P198" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb179" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P199" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P200" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P201" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001ea66e" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P202" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="00232940" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P203" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="00232940" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P204" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties style:text-underline-style="none" officeooo:paragraph-rsid="001cb179"/>
-  </style:style>
-  <style:style style:name="P205" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
-   <style:text-properties style:text-underline-style="none" officeooo:paragraph-rsid="001ea66e"/>
-  </style:style>
-  <style:style style:name="P206" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" fo:font-weight="bold" officeooo:paragraph-rsid="00232940" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P207" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="00232940" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P208" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="0021def5" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P209" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="00231ad9" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P210" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="003086e6" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P211" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P212" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:rsid="00231ad9" officeooo:paragraph-rsid="00231ad9" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P213" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:rsid="00231ad9" officeooo:paragraph-rsid="00232940" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P214" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:rsid="00231ad9" officeooo:paragraph-rsid="003086e6" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P215" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" fo:font-style="italic" fo:font-weight="bold" style:font-size-asian="11pt" style:font-style-asian="italic" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-style-complex="italic" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P216" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" fo:font-style="italic" fo:font-weight="bold" officeooo:paragraph-rsid="0021def5" style:font-size-asian="11pt" style:font-style-asian="italic" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-style-complex="italic" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="P217" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" fo:font-style="italic" fo:font-weight="normal" officeooo:paragraph-rsid="003086e6" style:font-size-asian="11pt" style:font-style-asian="italic" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-style-complex="italic" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P218" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false">
-    <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" fo:font-weight="normal" officeooo:paragraph-rsid="00231ad9" style:font-size-asian="11pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P219" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="00232940" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P220" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
-    <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
    <style:text-properties officeooo:paragraph-rsid="0029fe83"/>
   </style:style>
-  <style:style style:name="P221" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
-    <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties officeooo:paragraph-rsid="001cb179"/>
-  </style:style>
-  <style:style style:name="P222" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
-    <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties officeooo:paragraph-rsid="0021def5"/>
-  </style:style>
-  <style:style style:name="P223" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
-    <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P224" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
-    <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb179" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P225" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
-    <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P226" style:family="paragraph" style:parent-style-name="Text_20_body">
+  <style:style style:name="P13" style:family="paragraph" style:parent-style-name="Text_20_body">
    <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:line-height="138%" fo:text-indent="0in" style:auto-text-indent="false" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="1.9689in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties officeooo:paragraph-rsid="0029fe83"/>
+  </style:style>
+  <style:style style:name="P14" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
    <style:text-properties officeooo:paragraph-rsid="001ea66e"/>
   </style:style>
-  <style:style style:name="P227" style:family="paragraph" style:parent-style-name="Text_20_body">
+  <style:style style:name="P15" style:family="paragraph" style:parent-style-name="Text_20_body">
    <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:line-height="138%" fo:text-indent="0in" style:auto-text-indent="false" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="1.9689in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties officeooo:paragraph-rsid="001f7e27"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties officeooo:paragraph-rsid="001ea66e"/>
   </style:style>
-  <style:style style:name="P228" style:family="paragraph" style:parent-style-name="Text_20_body">
+  <style:style style:name="P16" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties officeooo:paragraph-rsid="001ea66e"/>
+  </style:style>
+  <style:style style:name="P17" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties officeooo:paragraph-rsid="001ea66e"/>
+  </style:style>
+  <style:style style:name="P18" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties officeooo:paragraph-rsid="001ea66e"/>
+  </style:style>
+  <style:style style:name="P19" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties officeooo:paragraph-rsid="00466870"/>
+  </style:style>
+  <style:style style:name="P20" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties officeooo:paragraph-rsid="0030f177"/>
+  </style:style>
+  <style:style style:name="P21" style:family="paragraph" style:parent-style-name="Text_20_body">
    <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:line-height="138%" fo:text-indent="0in" style:auto-text-indent="false" style:writing-mode="lr-tb">
-    <style:tab-stops>
-     <style:tab-stop style:position="1.9689in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties officeooo:paragraph-rsid="001cb179"/>
+  </style:style>
+  <style:style style:name="P22" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties officeooo:paragraph-rsid="001cb179"/>
+  </style:style>
+  <style:style style:name="P23" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties officeooo:paragraph-rsid="001cb179"/>
+  </style:style>
+  <style:style style:name="P24" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
    <style:text-properties officeooo:paragraph-rsid="0021def5"/>
   </style:style>
-  <style:style style:name="P229" style:family="paragraph" style:parent-style-name="Text_20_body">
+  <style:style style:name="P25" style:family="paragraph" style:parent-style-name="Text_20_body">
    <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
   </style:style>
-  <style:style style:name="P230" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P231" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:rsid="001cb086" officeooo:paragraph-rsid="001cb086" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P232" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="0021def5" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P233" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="003086e6" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P234" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="001ea66e" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P235" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
-   <style:text-properties style:text-underline-style="none"/>
-  </style:style>
-  <style:style style:name="P236" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
-   <style:text-properties style:text-underline-style="none" officeooo:paragraph-rsid="002d4b65"/>
-  </style:style>
-  <style:style style:name="P237" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <style:text-properties officeooo:rsid="0007edf0" officeooo:paragraph-rsid="0007edf0"/>
-  </style:style>
-  <style:style style:name="P238" style:family="paragraph" style:parent-style-name="Heading_20_2">
+  <style:style style:name="P26" style:family="paragraph" style:parent-style-name="Heading_20_2">
    <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
   </style:style>
-  <style:style style:name="P239" style:family="paragraph" style:parent-style-name="Text_20_body">
+  <style:style style:name="P27" style:family="paragraph" style:parent-style-name="Text_20_body">
    <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:background-color="transparent"/>
+   <style:paragraph-properties fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:background-color="transparent"/>
    <style:text-properties officeooo:paragraph-rsid="003b4dc5"/>
   </style:style>
-  <style:style style:name="P240" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  <style:style style:name="P28" style:family="paragraph" style:parent-style-name="Header">
+   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
+   <style:text-properties fo:font-weight="bold" officeooo:paragraph-rsid="003bb962" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
-  <style:style style:name="P241" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P242" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="004236e2" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P243" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P244" style:family="paragraph" style:parent-style-name="Text_20_body">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P245" style:family="paragraph" style:parent-style-name="Standard">
+  <style:style style:name="P29" style:family="paragraph" style:parent-style-name="Standard">
    <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-top="0.1181in" fo:margin-bottom="0.0783in" style:contextual-spacing="false">
+   <style:paragraph-properties fo:margin-top="0.3cm" fo:margin-bottom="0.199cm" style:contextual-spacing="false">
     <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
+     <style:tab-stop style:position="6.006cm"/>
     </style:tab-stops>
    </style:paragraph-properties>
    <style:text-properties fo:font-weight="bold" officeooo:paragraph-rsid="001cb179" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
-  <style:style style:name="P246" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-top="0.1181in" fo:margin-bottom="0.0783in" style:contextual-spacing="false">
+  <style:style style:name="P30" style:family="paragraph" style:parent-style-name="Header">
+   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
+   <style:text-properties fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="003bb962" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P31" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P32" style:family="paragraph" style:parent-style-name="Header">
+   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
+   <style:text-properties fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="00480aa3" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P33" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties>
     <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
+     <style:tab-stop style:position="6.006cm"/>
     </style:tab-stops>
    </style:paragraph-properties>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb179" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
-  <style:style style:name="P247" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-top="0.1965in" fo:margin-bottom="0.0783in" style:contextual-spacing="false">
+  <style:style style:name="P34" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P35" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="0029fe83" officeooo:paragraph-rsid="0029fe83" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P36" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" officeooo:paragraph-rsid="001cb179" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P37" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" officeooo:paragraph-rsid="0021def5" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P38" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83"/>
+  </style:style>
+  <style:style style:name="P39" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="11pt" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P40" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent">
     <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
+     <style:tab-stop style:position="5.001cm"/>
     </style:tab-stops>
    </style:paragraph-properties>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0033aaea" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
-  <style:style style:name="P248" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-top="0.1965in" fo:margin-bottom="0.0783in" style:contextual-spacing="false">
+  <style:style style:name="P41" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent">
     <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
+     <style:tab-stop style:position="5.001cm"/>
     </style:tab-stops>
    </style:paragraph-properties>
-   <style:text-properties officeooo:paragraph-rsid="003086e6"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0037be7b" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
-  <style:style style:name="P249" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <style:paragraph-properties style:page-number="auto" fo:break-before="auto" fo:break-after="auto"/>
-  </style:style>
-  <style:style style:name="P250" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <style:paragraph-properties style:page-number="auto" fo:break-before="auto" fo:break-after="auto"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P251" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <style:paragraph-properties style:page-number="auto" fo:break-before="auto" fo:break-after="auto"/>
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:paragraph-rsid="0033aaea" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="P252" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <style:paragraph-properties style:page-number="auto" fo:break-before="auto" fo:break-after="auto">
+  <style:style style:name="P42" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-top="0.3cm" fo:margin-bottom="0.199cm" style:contextual-spacing="false">
     <style:tab-stops>
-     <style:tab-stop style:position="1.9689in"/>
+     <style:tab-stop style:position="6.006cm"/>
     </style:tab-stops>
    </style:paragraph-properties>
-   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb179" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
-  <style:style style:name="P253" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <style:paragraph-properties style:page-number="auto" fo:break-before="auto" fo:break-after="auto"/>
-   <style:text-properties officeooo:paragraph-rsid="0033aaea"/>
-  </style:style>
-  <style:style style:name="P254" style:family="paragraph" style:parent-style-name="Standard">
+  <style:style style:name="P43" style:family="paragraph" style:parent-style-name="Standard">
    <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0.0783in" style:contextual-spacing="false">
+   <style:paragraph-properties fo:margin-top="0.499cm" fo:margin-bottom="0.199cm" style:contextual-spacing="false">
     <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
+     <style:tab-stop style:position="6.006cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P44" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P45" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="6.006cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="001cb086" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P46" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="6.006cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P47" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:rsid="001cb086" officeooo:paragraph-rsid="001cb086" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P48" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:rsid="001cb086" officeooo:paragraph-rsid="001cb086" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P49" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="001cb179" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P50" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="0021def5" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P51" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="0021def5" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P52" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="0021def5" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P53" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="00231ad9" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P54" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="00231ad9" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P55" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="5.001cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="00232940" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P56" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="003086e6" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P57" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="003086e6" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P58" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="003086e6" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P59" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="001ea66e" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P60" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="00200e99" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P61" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="003086e6" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P62" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P63" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="0033aaea" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P64" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <style:paragraph-properties style:page-number="auto" fo:break-before="auto" fo:break-after="auto"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="0033aaea" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P65" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P66" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:rsid="00231ad9" officeooo:paragraph-rsid="00231ad9" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P67" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:rsid="00231ad9" officeooo:paragraph-rsid="00232940" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P68" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:rsid="00231ad9" officeooo:paragraph-rsid="003086e6" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P69" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P70" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="001ea66e" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P71" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <style:paragraph-properties style:page-number="auto" fo:break-before="auto" fo:break-after="auto"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P72" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" fo:font-weight="bold" officeooo:paragraph-rsid="003086e6" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P73" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="5.001cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" fo:font-weight="bold" officeooo:rsid="003086e6" officeooo:paragraph-rsid="0033aaea" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P74" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" fo:font-weight="bold" officeooo:paragraph-rsid="00232940" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P75" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="11pt" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P76" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:font-size-asian="11pt" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P77" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:font-size-asian="11pt" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P78" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P79" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0037be7b" officeooo:paragraph-rsid="003a7a58" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P80" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P81" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" officeooo:rsid="0037be7b" officeooo:paragraph-rsid="00393dbe" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P82" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" fo:font-style="italic" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="11pt" style:font-style-asian="italic" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-style-complex="italic" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P83" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" fo:font-style="italic" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003e0772" style:font-size-asian="11pt" style:font-style-asian="italic" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-style-complex="italic" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P84" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" fo:font-style="italic" fo:font-weight="bold" style:font-size-asian="11pt" style:font-style-asian="italic" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-style-complex="italic" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P85" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" fo:font-style="italic" fo:font-weight="bold" officeooo:paragraph-rsid="0021def5" style:font-size-asian="11pt" style:font-style-asian="italic" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-style-complex="italic" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P86" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" fo:font-style="italic" fo:font-weight="normal" officeooo:paragraph-rsid="003086e6" style:font-size-asian="11pt" style:font-style-asian="italic" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-style-complex="italic" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P87" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false">
+    <style:tab-stops>
+     <style:tab-stop style:position="6.006cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" fo:font-weight="normal" officeooo:paragraph-rsid="00231ad9" style:font-size-asian="11pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P88" style:family="paragraph" style:parent-style-name="Footer">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties style:font-name="Arial1" officeooo:paragraph-rsid="00066dfa"/>
+  </style:style>
+  <style:style style:name="P89" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P90" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003e0772" style:font-size-asian="9pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P91" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="004151b0" style:font-size-asian="9pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P92" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="6.006cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties officeooo:paragraph-rsid="001b5069"/>
+  </style:style>
+  <style:style style:name="P93" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
+    <style:tab-stops>
+     <style:tab-stop style:position="6.006cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties officeooo:paragraph-rsid="0029fe83"/>
+  </style:style>
+  <style:style style:name="P94" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
+    <style:tab-stops>
+     <style:tab-stop style:position="6.006cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties officeooo:paragraph-rsid="0029fe83"/>
+  </style:style>
+  <style:style style:name="P95" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
+    <style:tab-stops>
+     <style:tab-stop style:position="6.006cm"/>
     </style:tab-stops>
    </style:paragraph-properties>
    <style:text-properties officeooo:paragraph-rsid="001cb179"/>
   </style:style>
-  <style:style style:name="P255" style:family="paragraph" style:parent-style-name="Standard">
+  <style:style style:name="P96" style:family="paragraph" style:parent-style-name="Standard">
    <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0.0783in" style:contextual-spacing="false">
+   <style:paragraph-properties fo:margin-top="0cm" fo:margin-bottom="0.199cm" style:contextual-spacing="false">
     <style:tab-stops>
-     <style:tab-stop style:position="2.3646in"/>
+     <style:tab-stop style:position="6.006cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties officeooo:paragraph-rsid="001cb179"/>
+  </style:style>
+  <style:style style:name="P97" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
+    <style:tab-stops>
+     <style:tab-stop style:position="6.006cm"/>
     </style:tab-stops>
    </style:paragraph-properties>
    <style:text-properties officeooo:paragraph-rsid="0021def5"/>
   </style:style>
-  <style:style style:name="P256" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3752in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="-0.25in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
+  <style:style style:name="P98" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-top="0cm" fo:margin-bottom="0.199cm" style:contextual-spacing="false">
     <style:tab-stops>
-     <style:tab-stop style:position="-0.0634in"/>
+     <style:tab-stop style:position="6.006cm"/>
     </style:tab-stops>
    </style:paragraph-properties>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="003086e6" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+   <style:text-properties officeooo:paragraph-rsid="0021def5"/>
   </style:style>
-  <style:style style:name="P257" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3752in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="-0.25in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
+  <style:style style:name="P99" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-top="0.499cm" fo:margin-bottom="0.199cm" style:contextual-spacing="false">
     <style:tab-stops>
-     <style:tab-stop style:position="-0.0634in"/>
+     <style:tab-stop style:position="6.006cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties officeooo:paragraph-rsid="003086e6"/>
+  </style:style>
+  <style:style style:name="P100" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties officeooo:paragraph-rsid="001cb179"/>
+  </style:style>
+  <style:style style:name="P101" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb086" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P102" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P103" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P104" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P105" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P106" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0037be7b" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P107" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb179" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P108" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb179" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P109" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb179" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P110" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb179" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P111" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P112" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P113" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P114" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P115" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P116" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P117" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="00200e99" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P118" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="00231ad9" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P119" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P120" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P121" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P122" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P123" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001ea66e" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P124" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001ea66e" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P125" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001ea66e" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P126" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="00232940" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P127" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="00232940" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P128" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="00232940" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P129" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="00232940" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P130" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0029fe83" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P131" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002d4b65" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P132" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002d4b65" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P133" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P134" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="00231ad9" officeooo:paragraph-rsid="00231ad9" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P135" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent">
+    <style:tab-stops>
+     <style:tab-stop style:position="5.001cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0037be7b" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P136" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P137" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent">
+    <style:tab-stops>
+     <style:tab-stop style:position="5.001cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0037be7b" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P138" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" officeooo:paragraph-rsid="00232940" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P139" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P140" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P141" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P142" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="00231ad9" officeooo:paragraph-rsid="00231ad9" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P143" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P144" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P145" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P146" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0.953cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="-0.635cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
+    <style:tab-stops>
+     <style:tab-stop style:position="-0.161cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="003086e6" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P147" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0.953cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="-0.635cm" style:auto-text-indent="false" fo:background-color="transparent">
+    <style:tab-stops>
+     <style:tab-stop style:position="-0.161cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="003086e6" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P148" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P149" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="003086e6" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P150" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent"/>
+  </style:style>
+  <style:style style:name="P151" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:break-before="page" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent"/>
+  </style:style>
+  <style:style style:name="P152" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent"/>
+  </style:style>
+  <style:style style:name="P153" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:paragraph-rsid="001cb179" style:text-blinking="false" fo:background-color="transparent"/>
+  </style:style>
+  <style:style style:name="P154" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P155" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P156" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P157" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb179" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P158" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001ea66e" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P159" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P160" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P161" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
+    <style:tab-stops>
+     <style:tab-stop style:position="6.006cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P162" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
+    <style:tab-stops>
+     <style:tab-stop style:position="6.006cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="001cb179" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P163" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
+    <style:tab-stops>
+     <style:tab-stop style:position="6.006cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P164" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent"/>
+  </style:style>
+  <style:style style:name="P165" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0021def5" style:text-blinking="false" fo:background-color="transparent"/>
+  </style:style>
+  <style:style style:name="P166" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent"/>
+  </style:style>
+  <style:style style:name="P167" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent"/>
+  </style:style>
+  <style:style style:name="P168" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002d4b65" officeooo:paragraph-rsid="002d4b65" style:text-blinking="false" fo:background-color="transparent"/>
+  </style:style>
+  <style:style style:name="P169" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002d4b65" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent"/>
+  </style:style>
+  <style:style style:name="P170" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P171" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P172" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P173" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P174" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00466870" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P175" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002d4b65" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent"/>
+  </style:style>
+  <style:style style:name="P176" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P177" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="003086e6" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P178" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P179" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P180" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P181" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P182" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P183" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P184" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0.953cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="-0.635cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
+    <style:tab-stops>
+     <style:tab-stop style:position="-0.161cm"/>
     </style:tab-stops>
    </style:paragraph-properties>
    <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="003086e6" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="P258" style:family="paragraph" style:parent-style-name="Standard">
+  <style:style style:name="P185" style:family="paragraph" style:parent-style-name="Standard">
    <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3752in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="-0.25in" style:auto-text-indent="false" fo:background-color="transparent">
+   <style:paragraph-properties fo:margin-left="0.953cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="-0.635cm" style:auto-text-indent="false" fo:background-color="transparent">
     <style:tab-stops>
-     <style:tab-stop style:position="-0.0634in"/>
-    </style:tab-stops>
-   </style:paragraph-properties>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="003086e6" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="P259" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3752in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="-0.25in" style:auto-text-indent="false" fo:background-color="transparent">
-    <style:tab-stops>
-     <style:tab-stop style:position="-0.0634in"/>
+     <style:tab-stop style:position="-0.161cm"/>
     </style:tab-stops>
    </style:paragraph-properties>
    <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="003086e6" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="P260" style:family="paragraph" style:parent-style-name="Table_20_Heading">
+  <style:style style:name="P186" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P187" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003bb962" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P188" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003bb962" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P189" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P190" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003bb962" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P191" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00466870" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P192" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="004151b0" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P193" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="5.001cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P194" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <style:paragraph-properties style:page-number="auto" fo:break-before="auto" fo:break-after="auto">
+    <style:tab-stops>
+     <style:tab-stop style:position="5.001cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P195" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="5.001cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" officeooo:paragraph-rsid="0033aaea" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P196" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P197" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P198" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83"/>
+  </style:style>
+  <style:style style:name="P199" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0037be7b"/>
+  </style:style>
+  <style:style style:name="P200" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003dbced" style:font-size-asian="11pt" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P201" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P202" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P203" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P204" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P205" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P206" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P207" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P208" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P209" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P210" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="003086e6" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P211" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003dbced" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P212" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P213" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P214" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0042065a" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P215" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P216" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="004236e2" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P217" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P218" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial2" officeooo:paragraph-rsid="0030f177"/>
+  </style:style>
+  <style:style style:name="P219" style:family="paragraph" style:parent-style-name="Table_20_Contents">
    <style:paragraph-properties fo:text-align="end" style:justify-single-word="false"/>
   </style:style>
-  <style:style style:name="P261" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="4.4409in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
+  <style:style style:name="P220" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:paragraph-properties fo:text-align="end" style:justify-single-word="false"/>
+   <style:text-properties officeooo:paragraph-rsid="0008048e"/>
   </style:style>
-  <style:style style:name="P262" style:family="paragraph" style:parent-style-name="Standard">
-   <style:paragraph-properties fo:margin-left="4.4409in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
+  <style:style style:name="P221" style:family="paragraph" style:parent-style-name="Table_20_Heading">
+   <style:paragraph-properties fo:text-align="end" style:justify-single-word="false"/>
+  </style:style>
+  <style:style style:name="P222" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P223" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0037be7b" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P224" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0037be7b" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P225" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="003b4dc5" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P226" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P227" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P228" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P229" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P230" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003dbced" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P231" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0042065a" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P232" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="004236e2" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P233" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="0.305cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0043a2e0" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P234" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:line-height="0.305cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0043a2e0" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P235" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="0.305cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="004236e2" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P236" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0037be7b" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P237" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P238" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="003dbced" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P239" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="0043a2e0" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P240" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P241" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P242" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="0.305cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P243" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="P244" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties officeooo:rsid="001b5069" officeooo:paragraph-rsid="0029fe83"/>
+  </style:style>
+  <style:style style:name="P245" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties officeooo:paragraph-rsid="001b5069"/>
+  </style:style>
+  <style:style style:name="P246" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:break-before="page"/>
+   <style:text-properties fo:font-size="6pt" officeooo:paragraph-rsid="0011a01d" style:font-size-asian="5.25pt" style:font-size-complex="6pt"/>
+  </style:style>
+  <style:style style:name="P247" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:text-underline-style="none" officeooo:paragraph-rsid="002d4b65"/>
+  </style:style>
+  <style:style style:name="P248" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
+   <style:text-properties style:text-underline-style="none" officeooo:paragraph-rsid="002d4b65"/>
+  </style:style>
+  <style:style style:name="P249" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:text-underline-style="none" officeooo:paragraph-rsid="001cb179"/>
+  </style:style>
+  <style:style style:name="P250" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties style:text-underline-style="none" officeooo:paragraph-rsid="001cb179"/>
+  </style:style>
+  <style:style style:name="P251" style:family="paragraph" style:parent-style-name="Text_20_body" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties style:text-underline-style="none" officeooo:paragraph-rsid="001ea66e"/>
+  </style:style>
+  <style:style style:name="P252" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
+   <style:text-properties style:text-underline-style="none"/>
+  </style:style>
+  <style:style style:name="P253" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:text-underline-style="none" officeooo:paragraph-rsid="003086e6"/>
+  </style:style>
+  <style:style style:name="P254" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:font-name="Liberation Serif"/>
+  </style:style>
+  <style:style style:name="P255" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:font-name="Liberation Serif"/>
+  </style:style>
+  <style:style style:name="P256" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+   <style:text-properties style:font-name="Liberation Serif" officeooo:paragraph-rsid="0014b27d"/>
+  </style:style>
+  <style:style style:name="P257" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="138%" fo:text-indent="0cm" style:auto-text-indent="false" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="5.001cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties officeooo:paragraph-rsid="001ea66e"/>
+  </style:style>
+  <style:style style:name="P258" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="138%" fo:text-indent="0cm" style:auto-text-indent="false" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="5.001cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties officeooo:paragraph-rsid="001f7e27"/>
+  </style:style>
+  <style:style style:name="P259" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="1cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="138%" fo:text-indent="0cm" style:auto-text-indent="false" style:writing-mode="lr-tb">
+    <style:tab-stops>
+     <style:tab-stop style:position="5.001cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties officeooo:paragraph-rsid="0021def5"/>
+  </style:style>
+  <style:style style:name="P260" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:text-properties officeooo:rsid="0007edf0" officeooo:paragraph-rsid="0007edf0"/>
+  </style:style>
+  <style:style style:name="P261" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <style:paragraph-properties style:page-number="auto" fo:break-before="auto" fo:break-after="auto"/>
+  </style:style>
+  <style:style style:name="P262" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <style:paragraph-properties style:page-number="auto" fo:break-before="auto" fo:break-after="auto"/>
+   <style:text-properties officeooo:paragraph-rsid="0033aaea"/>
+  </style:style>
+  <style:style style:name="P263" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="11.28cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
+  </style:style>
+  <style:style style:name="P264" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:margin-left="11.28cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false"/>
    <style:text-properties officeooo:paragraph-rsid="0011a01d"/>
   </style:style>
-  <style:style style:name="P263" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <style:paragraph-properties fo:margin-left="4.4409in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:break-before="page"/>
+  <style:style style:name="P265" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <style:paragraph-properties fo:margin-left="11.28cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:break-before="page"/>
    <style:text-properties officeooo:paragraph-rsid="0011a01d"/>
   </style:style>
-  <style:style style:name="P264" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
-   <style:paragraph-properties fo:margin-left="4.4409in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" style:page-number="auto" fo:break-before="page"/>
+  <style:style style:name="P266" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <style:paragraph-properties fo:margin-left="11.28cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:break-before="page"/>
    <style:text-properties officeooo:paragraph-rsid="000ce218"/>
   </style:style>
-  <style:style style:name="P265" style:family="paragraph" style:parent-style-name="Heading_20_1">
+  <style:style style:name="P267" style:family="paragraph" style:parent-style-name="Heading_20_1">
    <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
    <style:text-properties style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color"/>
   </style:style>
-  <style:style style:name="P266" style:family="paragraph" style:parent-style-name="Header">
+  <style:style style:name="P268" style:family="paragraph" style:parent-style-name="Header">
    <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
-   <style:text-properties fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="00480aa3" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="003bb962" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="P267" style:family="paragraph" style:parent-style-name="Standard" style:list-style-name="L1" style:master-page-name="">
+  <style:style style:name="P269" style:family="paragraph" style:parent-style-name="Header">
+   <style:paragraph-properties fo:text-align="start" style:justify-single-word="false"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="00480aa3" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P270" style:family="paragraph" style:parent-style-name="Standard">
    <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3752in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="-0.25in" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0037be7b" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P271" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P272" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent">
     <style:tab-stops>
-     <style:tab-stop style:position="-0.0634in"/>
+     <style:tab-stop style:position="5.001cm"/>
     </style:tab-stops>
    </style:paragraph-properties>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="003086e6" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0037be7b" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="P268" style:family="paragraph" style:parent-style-name="Standard" style:list-style-name="L1">
+  <style:style style:name="P273" style:family="paragraph" style:parent-style-name="Standard">
    <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0.3752in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="-0.25in" style:auto-text-indent="false" fo:background-color="transparent">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="end" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P274" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="004151b0" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P275" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003bb962" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P276" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00466870" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P277" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P278" style:family="paragraph" style:parent-style-name="Standard" style:list-style-name="L1">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0.953cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="-0.635cm" style:auto-text-indent="false" fo:background-color="transparent">
     <style:tab-stops>
-     <style:tab-stop style:position="-0.0634in"/>
+     <style:tab-stop style:position="-0.161cm"/>
     </style:tab-stops>
    </style:paragraph-properties>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="003086e6" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="003086e6" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="P269" style:family="paragraph" style:parent-style-name="Standard">
-   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00393dbe" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  <style:style style:name="P279" style:family="paragraph" style:parent-style-name="Standard" style:list-style-name="L1" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0.953cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="-0.635cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent">
+    <style:tab-stops>
+     <style:tab-stop style:position="-0.161cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="003086e6" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="P270" style:family="paragraph" style:parent-style-name="Text_20_body">
+  <style:style style:name="P280" style:family="paragraph" style:parent-style-name="Standard">
    <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003bb962" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
   </style:style>
-  <style:style style:name="P271" style:family="paragraph" style:parent-style-name="Text_20_body">
+  <style:style style:name="P281" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="002df04f" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P282" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="003086e6" officeooo:paragraph-rsid="003086e6" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P283" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <style:paragraph-properties style:page-number="auto" fo:break-before="auto" fo:break-after="auto"/>
+   <style:text-properties style:font-name="Arial1" officeooo:paragraph-rsid="0033aaea"/>
+  </style:style>
+  <style:style style:name="P284" style:family="paragraph" style:parent-style-name="Standard" style:master-page-name="">
+   <loext:graphic-properties draw:fill="none"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:text-indent="0cm" style:auto-text-indent="false" style:page-number="auto" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="0033aaea" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P285" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="5.001cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:paragraph-rsid="0033aaea" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="P286" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="5.001cm"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" fo:font-weight="bold" officeooo:rsid="003086e6" officeooo:paragraph-rsid="0033aaea" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P287" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001b5069" officeooo:paragraph-rsid="0037be7b"/>
+  </style:style>
+  <style:style style:name="P288" style:family="paragraph" style:parent-style-name="Standard">
    <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
-   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0in" style:auto-text-indent="false" fo:background-color="transparent"/>
-   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0037be7b" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P289" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P290" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="004151b0" style:font-size-asian="9pt" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-style-complex="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P291" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P292" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003dbced" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P293" style:family="paragraph" style:parent-style-name="Standard">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="004a6cd0" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P294" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P295" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0037be7b" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P296" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P297" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P298" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="004236e2" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P299" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="004236e2" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P300" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0042065a" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P301" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:line-height="0.305cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0043a2e0" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P302" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="0.305cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0043a2e0" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P303" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="0.305cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="004236e2" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P304" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0.212cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" officeooo:rsid="003b4dc5" officeooo:paragraph-rsid="004a6cd0" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="P305" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" fo:font-weight="normal" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P306" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:line-height="0.305cm" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="9pt" fo:font-weight="normal" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="003b4dc5" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="P307" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties style:font-name="Arial1" officeooo:paragraph-rsid="00466870"/>
+  </style:style>
+  <style:style style:name="P308" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P309" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <loext:graphic-properties draw:fill="none" draw:fill-gradient-name="gradient" draw:fill-hatch-name="hatch"/>
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm" fo:margin-bottom="0cm" style:contextual-spacing="false" fo:text-align="start" style:justify-single-word="false" fo:text-indent="0cm" style:auto-text-indent="false" fo:background-color="transparent"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" officeooo:paragraph-rsid="00466870" style:text-blinking="false" fo:background-color="transparent" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T1" style:family="text">
-   <style:text-properties style:font-name="Arial" officeooo:rsid="00231ad9"/>
+   <style:text-properties style:font-name="Arial1" officeooo:rsid="00231ad9"/>
   </style:style>
   <style:style style:name="T2" style:family="text">
-   <style:text-properties style:font-name="Arial"/>
+   <style:text-properties style:font-name="Arial1"/>
   </style:style>
   <style:style style:name="T3" style:family="text">
-   <style:text-properties style:font-name="Arial"/>
+   <style:text-properties style:font-name="Arial1"/>
   </style:style>
   <style:style style:name="T4" style:family="text">
-   <style:text-properties style:font-name="Arial" officeooo:rsid="00231ad9"/>
+   <style:text-properties style:font-name="Arial1" officeooo:rsid="00231ad9"/>
   </style:style>
   <style:style style:name="T5" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T6" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T7" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T8" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" officeooo:rsid="003b4dc5" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" officeooo:rsid="003b4dc5" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T9" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T10" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" officeooo:rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" officeooo:rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T11" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T12" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T13" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T14" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001cb179" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001cb179" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T15" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="0029fe83" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="0029fe83" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T16" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T17" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T18" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0029fe83" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0029fe83" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T19" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T20" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" fo:font-weight="bold" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" fo:font-weight="bold" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T21" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-size="11pt" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="Arial1" fo:font-size="11pt" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T22" style:family="text">
-   <style:text-properties style:font-name="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial1" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T23" style:family="text">
-   <style:text-properties style:font-name="Arial" officeooo:rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial1" officeooo:rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T24" style:family="text">
-   <style:text-properties style:font-name="Arial" fo:font-weight="bold" officeooo:rsid="003086e6" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="Arial1" fo:font-weight="bold" officeooo:rsid="003086e6" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T25" style:family="text">
-   <style:text-properties style:font-name="Arial" style:text-underline-style="none" officeooo:rsid="001b5069"/>
+   <style:text-properties style:font-name="Arial1" style:text-underline-style="none" officeooo:rsid="001b5069"/>
   </style:style>
   <style:style style:name="T26" style:family="text">
-   <style:text-properties style:font-name="Arial" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+   <style:text-properties style:font-name="Arial1" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
   <style:style style:name="T27" style:family="text">
-   <style:text-properties style:font-name="Arial" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0037be7b" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+   <style:text-properties style:font-name="Arial1" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0037be7b" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
   <style:style style:name="T28" style:family="text">
-   <style:text-properties style:font-name="Arial" style:text-underline-style="none" officeooo:rsid="0031e6f3"/>
+   <style:text-properties style:font-name="Arial1" style:text-underline-style="none" officeooo:rsid="0031e6f3"/>
   </style:style>
   <style:style style:name="T29" style:family="text">
    <style:text-properties fo:font-size="13pt" fo:font-weight="bold" officeooo:rsid="001b5069" style:font-size-asian="13pt" style:font-weight-asian="bold" style:font-size-complex="13pt"/>
@@ -1880,351 +2090,375 @@
    <style:text-properties style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0037be7b" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
   <style:style style:name="T49" style:family="text">
-   <style:text-properties style:text-underline-style="none" officeooo:rsid="003b4dc5"/>
+   <style:text-properties style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
   <style:style style:name="T50" style:family="text">
-   <style:text-properties fo:font-size="12pt" style:font-size-asian="12pt" style:font-size-complex="12pt"/>
+   <style:text-properties style:text-underline-style="none" officeooo:rsid="003b4dc5"/>
   </style:style>
   <style:style style:name="T51" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties fo:font-size="12pt" style:font-size-asian="12pt" style:font-size-complex="12pt"/>
   </style:style>
   <style:style style:name="T52" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-size="11pt" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T53" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-size="11pt" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T54" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T55" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001cb179" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
   </style:style>
   <style:style style:name="T56" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
   </style:style>
   <style:style style:name="T57" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" fo:font-weight="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001cb179" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
   </style:style>
   <style:style style:name="T58" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-underline-style="none" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
   </style:style>
   <style:style style:name="T59" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" fo:font-weight="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" fo:font-weight="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
   </style:style>
   <style:style style:name="T60" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
   </style:style>
   <style:style style:name="T61" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="0034857e" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" fo:font-weight="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T62" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" fo:font-weight="bold" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T63" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" fo:font-weight="bold" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="0034857e" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T64" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" fo:font-weight="bold" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T65" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" fo:font-weight="bold" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T66" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-style="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
   </style:style>
   <style:style style:name="T67" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001ea66e" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T68" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002183d4" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="T69" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="T70" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="T71" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="T72" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-style="normal" fo:font-weight="bold" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="T73" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-style="normal" fo:font-weight="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
-  </style:style>
-  <style:style style:name="T74" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
-  </style:style>
-  <style:style style:name="T75" style:family="text">
    <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
-  <style:style style:name="T76" style:family="text">
+  <style:style style:name="T69" style:family="text">
    <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001ea66e" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
-  <style:style style:name="T77" style:family="text">
+  <style:style style:name="T70" style:family="text">
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="002183d4" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="T71" style:family="text">
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0029fe83" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="T72" style:family="text">
    <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
+  <style:style style:name="T73" style:family="text">
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="T74" style:family="text">
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-style="normal" fo:font-weight="bold" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="T75" style:family="text">
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-style="normal" fo:font-weight="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
+  <style:style style:name="T76" style:family="text">
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
+  </style:style>
+  <style:style style:name="T77" style:family="text">
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+  </style:style>
   <style:style style:name="T78" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-size="11pt" fo:font-style="italic" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="001ea66e" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T79" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial1" fo:font-style="normal" fo:font-weight="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="normal" fo:font-weight="normal" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T80" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-size="11pt" fo:font-style="italic" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="001b5069" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T81" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial" fo:font-style="normal" fo:font-weight="normal" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
   </style:style>
   <style:style style:name="T82" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-style="normal" style:text-underline-style="none" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T83" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" style:text-underline-style="none" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T84" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="003b4dc5" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" fo:font-style="normal" style:text-underline-style="none" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
   </style:style>
   <style:style style:name="T85" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" style:text-underline-style="none" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0"/>
   </style:style>
   <style:style style:name="T86" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="mononoki" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="003b4dc5" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T87" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T88" style:family="text">
-   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#e01e5a" loext:opacity="100%" style:font-name="Monaco" fo:font-size="9pt" fo:letter-spacing="normal" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="11pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T89" style:family="text">
-   <style:text-properties officeooo:rsid="001b5069"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Arial2" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T90" style:family="text">
-   <style:text-properties style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="003b4dc5" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T91" style:family="text">
-   <style:text-properties officeooo:rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#000000" loext:opacity="100%" style:text-line-through-style="none" style:text-line-through-type="none" fo:font-size="9pt" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:text-blinking="false" fo:background-color="transparent" loext:char-shading-value="0" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T92" style:family="text">
-   <style:text-properties officeooo:rsid="0029fe83"/>
+   <style:text-properties fo:font-variant="normal" fo:text-transform="none" fo:color="#e01e5a" loext:opacity="100%" style:font-name="Monaco" fo:font-size="9pt" fo:letter-spacing="normal" fo:font-style="normal" style:text-underline-style="none" fo:font-weight="normal"/>
   </style:style>
   <style:style style:name="T93" style:family="text">
-   <style:text-properties fo:font-style="italic" fo:font-weight="bold"/>
+   <style:text-properties officeooo:rsid="001b5069"/>
   </style:style>
   <style:style style:name="T94" style:family="text">
-   <style:text-properties fo:font-style="italic" fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T95" style:family="text">
-   <style:text-properties fo:font-style="italic" style:text-underline-style="none" style:font-style-asian="italic" style:font-style-complex="italic"/>
+   <style:text-properties officeooo:rsid="001b5069" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T96" style:family="text">
-   <style:text-properties fo:font-style="italic" style:text-underline-style="none" fo:font-weight="bold" style:font-style-asian="italic" style:font-weight-asian="bold" style:font-style-complex="italic" style:font-weight-complex="bold"/>
+   <style:text-properties officeooo:rsid="0029fe83"/>
   </style:style>
   <style:style style:name="T97" style:family="text">
-   <style:text-properties fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-style="italic" fo:font-weight="bold"/>
   </style:style>
   <style:style style:name="T98" style:family="text">
-   <style:text-properties fo:font-weight="bold" officeooo:rsid="001b5069" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-style="italic" fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T99" style:family="text">
-   <style:text-properties fo:font-weight="bold" officeooo:rsid="003086e6" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-style="italic" style:text-underline-style="none" style:font-style-asian="italic" style:font-style-complex="italic"/>
   </style:style>
   <style:style style:name="T100" style:family="text">
-   <style:text-properties fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-style="italic" style:text-underline-style="none" fo:font-weight="bold" style:font-style-asian="italic" style:font-weight-asian="bold" style:font-style-complex="italic" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T101" style:family="text">
-   <style:text-properties fo:font-weight="bold" officeooo:rsid="003f5e17" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T102" style:family="text">
-   <style:text-properties style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-weight="bold" officeooo:rsid="001b5069" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T103" style:family="text">
-   <style:text-properties officeooo:rsid="003086e6"/>
+   <style:text-properties fo:font-weight="bold" officeooo:rsid="003086e6" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T104" style:family="text">
-   <style:text-properties officeooo:rsid="0031e6f3"/>
+   <style:text-properties fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T105" style:family="text">
-   <style:text-properties officeooo:rsid="003a7a58"/>
+   <style:text-properties fo:font-weight="bold" officeooo:rsid="003f5e17" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T106" style:family="text">
-   <style:text-properties style:font-name="Arial2"/>
+   <style:text-properties style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T107" style:family="text">
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" fo:font-weight="normal" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+   <style:text-properties officeooo:rsid="003086e6"/>
   </style:style>
   <style:style style:name="T108" style:family="text">
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+   <style:text-properties officeooo:rsid="0031e6f3"/>
   </style:style>
   <style:style style:name="T109" style:family="text">
-   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+   <style:text-properties officeooo:rsid="003a7a58"/>
   </style:style>
   <style:style style:name="T110" style:family="text">
-   <style:text-properties style:font-name="Arial2" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="Arial2"/>
   </style:style>
   <style:style style:name="T111" style:family="text">
-   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" fo:font-weight="normal" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
   </style:style>
   <style:style style:name="T112" style:family="text">
-   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
   </style:style>
   <style:style style:name="T113" style:family="text">
-   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
   </style:style>
   <style:style style:name="T114" style:family="text">
-   <style:text-properties style:font-name="Arial2" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="Arial2" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T115" style:family="text">
-   <style:text-properties style:font-name="Arial2" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="003086e6" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T116" style:family="text">
-   <style:text-properties style:font-name="Arial2" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T117" style:family="text">
-   <style:text-properties style:font-name="Arial2" style:text-underline-style="none" officeooo:rsid="0031e6f3"/>
+   <style:text-properties style:font-name="Arial2" fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T118" style:family="text">
-   <style:text-properties style:font-name="Arial2" style:text-underline-style="none" officeooo:rsid="003086e6"/>
+   <style:text-properties style:font-name="Arial2" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T119" style:family="text">
-   <style:text-properties style:font-name="Arial2" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+   <style:text-properties style:font-name="Arial2" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="003086e6" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T120" style:family="text">
-   <style:text-properties style:font-name="Arial2" officeooo:rsid="0031e6f3"/>
+   <style:text-properties style:font-name="Arial2" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0031e6f3" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
   <style:style style:name="T121" style:family="text">
-   <style:text-properties style:font-name="Arial2" officeooo:rsid="003f5e17"/>
+   <style:text-properties style:font-name="Arial2" style:text-underline-style="none" officeooo:rsid="0031e6f3"/>
   </style:style>
   <style:style style:name="T122" style:family="text">
-   <style:text-properties fo:font-size="11pt" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial2" style:text-underline-style="none" officeooo:rsid="003086e6"/>
   </style:style>
   <style:style style:name="T123" style:family="text">
-   <style:text-properties fo:font-size="11pt" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial2" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
   <style:style style:name="T124" style:family="text">
-   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="Arial2" officeooo:rsid="0031e6f3"/>
   </style:style>
   <style:style style:name="T125" style:family="text">
-   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties style:font-name="Arial2" officeooo:rsid="003f5e17"/>
   </style:style>
   <style:style style:name="T126" style:family="text">
-   <style:text-properties fo:font-size="11pt" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-size="11pt" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T127" style:family="text">
-   <style:text-properties style:font-name="mononoki"/>
+   <style:text-properties fo:font-size="11pt" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T128" style:family="text">
-   <style:text-properties style:font-name="mononoki" fo:font-size="11pt" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
+   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T129" style:family="text">
-   <style:text-properties style:font-name="mononoki" fo:font-size="11pt" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T130" style:family="text">
-   <style:text-properties style:font-name="mononoki" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
+   <style:text-properties fo:font-size="11pt" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T131" style:family="text">
-   <style:text-properties style:font-name="mononoki" fo:font-size="7pt" style:font-size-asian="7pt" style:font-size-complex="7pt"/>
+   <style:text-properties fo:font-size="11pt" fo:font-weight="bold" officeooo:rsid="001b5069" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T132" style:family="text">
-   <style:text-properties style:font-name="mononoki" fo:font-size="10pt" style:font-size-asian="10pt" style:font-size-complex="10pt"/>
+   <style:text-properties style:font-name="mononoki"/>
   </style:style>
   <style:style style:name="T133" style:family="text">
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="11pt" style:font-size-asian="11pt" style:font-size-complex="11pt"/>
   </style:style>
   <style:style style:name="T134" style:family="text">
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="11pt" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T135" style:family="text">
-   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0037be7b" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="11pt" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-size-asian="11pt" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="T136" style:family="text">
-   <style:text-properties style:font-name="mononoki" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="7pt" style:font-size-asian="7pt" style:font-size-complex="7pt"/>
   </style:style>
   <style:style style:name="T137" style:family="text">
-   <style:text-properties style:font-name="mononoki" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="10pt" style:font-size-asian="10pt" style:font-size-complex="10pt"/>
   </style:style>
   <style:style style:name="T138" style:family="text">
-   <style:text-properties officeooo:rsid="003f5e17"/>
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
   </style:style>
   <style:style style:name="T139" style:family="text">
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="T140" style:family="text">
+   <style:text-properties style:font-name="mononoki" fo:font-size="9pt" style:text-underline-style="none" fo:font-weight="normal" officeooo:rsid="0037be7b" style:font-size-asian="9pt" style:font-weight-asian="normal" style:font-size-complex="9pt" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="T141" style:family="text">
+   <style:text-properties style:font-name="mononoki" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="T142" style:family="text">
+   <style:text-properties style:font-name="mononoki" style:text-underline-style="none" fo:font-weight="bold" officeooo:rsid="0031e6f3" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="T143" style:family="text">
+   <style:text-properties officeooo:rsid="003f5e17"/>
+  </style:style>
+  <style:style style:name="T144" style:family="text">
    <style:text-properties fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
   </style:style>
+  <style:style style:name="T145" style:family="text">
+   <style:text-properties fo:font-size="10pt" style:font-size-asian="10pt" style:font-size-complex="10pt"/>
+  </style:style>
+  <style:style style:name="T146" style:family="text">
+   <style:text-properties officeooo:rsid="004a6cd0"/>
+  </style:style>
   <style:style style:name="fr1" style:family="graphic" style:parent-style-name="Graphics">
-   <style:graphic-properties fo:margin-left="0.1252in" fo:margin-right="0.1252in" fo:margin-top="0.1252in" fo:margin-bottom="0.1252in" style:run-through="background" style:wrap="run-through" style:number-wrapped-paragraphs="no-limit" style:vertical-pos="from-top" style:vertical-rel="paragraph" style:horizontal-pos="from-left" style:horizontal-rel="paragraph" fo:background-color="transparent" draw:fill="none" draw:fill-color="#ffffff" fo:padding="0in" fo:border="none" style:mirror="none" fo:clip="rect(0in, 0in, 0in, 0in)" draw:luminance="0%" draw:contrast="0%" draw:red="0%" draw:green="0%" draw:blue="0%" draw:gamma="100%" draw:color-inversion="false" draw:image-opacity="100%" draw:color-mode="standard"/>
+   <style:graphic-properties fo:margin-left="0.318cm" fo:margin-right="0.318cm" fo:margin-top="0.318cm" fo:margin-bottom="0.318cm" style:run-through="background" style:wrap="run-through" style:number-wrapped-paragraphs="no-limit" style:vertical-pos="from-top" style:vertical-rel="paragraph" style:horizontal-pos="from-left" style:horizontal-rel="paragraph" fo:background-color="transparent" draw:fill="none" draw:fill-color="#ffffff" fo:padding="0cm" fo:border="none" style:mirror="none" fo:clip="rect(0cm, 0cm, 0cm, 0cm)" draw:luminance="0%" draw:contrast="0%" draw:red="0%" draw:green="0%" draw:blue="0%" draw:gamma="100%" draw:color-inversion="false" draw:image-opacity="100%" draw:color-mode="standard"/>
   </style:style>
   <text:list-style style:name="L1">
-   <text:list-level-style-bullet text:level="1" text:style-name="Bullet_20_Symbols" text:bullet-char="•">
+   <text:list-level-style-bullet text:level="1" text:style-name="Bullet_20_Symbols" loext:num-list-format="%1%" text:bullet-char="•">
     <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.5in" fo:text-indent="-0.25in" fo:margin-left="0.5in"/>
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.27cm" fo:text-indent="-0.635cm" fo:margin-left="1.27cm"/>
     </style:list-level-properties>
     <style:text-properties fo:font-family="OpenSymbol" style:font-charset="x-symbol"/>
    </text:list-level-style-bullet>
-   <text:list-level-style-bullet text:level="2" text:style-name="Bullet_20_Symbols" text:bullet-char="◦">
+   <text:list-level-style-bullet text:level="2" text:style-name="Bullet_20_Symbols" loext:num-list-format="%2%" text:bullet-char="◦">
     <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.75in" fo:text-indent="-0.25in" fo:margin-left="0.75in"/>
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.905cm" fo:text-indent="-0.635cm" fo:margin-left="1.905cm"/>
     </style:list-level-properties>
    </text:list-level-style-bullet>
-   <text:list-level-style-bullet text:level="3" text:style-name="Bullet_20_Symbols" text:bullet-char="▪">
+   <text:list-level-style-bullet text:level="3" text:style-name="Bullet_20_Symbols" loext:num-list-format="%3%" text:bullet-char="▪">
     <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1in" fo:text-indent="-0.25in" fo:margin-left="1in"/>
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.54cm" fo:text-indent="-0.635cm" fo:margin-left="2.54cm"/>
     </style:list-level-properties>
    </text:list-level-style-bullet>
-   <text:list-level-style-bullet text:level="4" text:style-name="Bullet_20_Symbols" text:bullet-char="•">
+   <text:list-level-style-bullet text:level="4" text:style-name="Bullet_20_Symbols" loext:num-list-format="%4%" text:bullet-char="•">
     <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.25in" fo:text-indent="-0.25in" fo:margin-left="1.25in"/>
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="3.175cm" fo:text-indent="-0.635cm" fo:margin-left="3.175cm"/>
     </style:list-level-properties>
    </text:list-level-style-bullet>
-   <text:list-level-style-bullet text:level="5" text:style-name="Bullet_20_Symbols" text:bullet-char="◦">
+   <text:list-level-style-bullet text:level="5" text:style-name="Bullet_20_Symbols" loext:num-list-format="%5%" text:bullet-char="◦">
     <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.5in" fo:text-indent="-0.25in" fo:margin-left="1.5in"/>
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="3.81cm" fo:text-indent="-0.635cm" fo:margin-left="3.81cm"/>
     </style:list-level-properties>
    </text:list-level-style-bullet>
-   <text:list-level-style-bullet text:level="6" text:style-name="Bullet_20_Symbols" text:bullet-char="▪">
+   <text:list-level-style-bullet text:level="6" text:style-name="Bullet_20_Symbols" loext:num-list-format="%6%" text:bullet-char="▪">
     <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.75in" fo:text-indent="-0.25in" fo:margin-left="1.75in"/>
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="4.445cm" fo:text-indent="-0.635cm" fo:margin-left="4.445cm"/>
     </style:list-level-properties>
    </text:list-level-style-bullet>
-   <text:list-level-style-bullet text:level="7" text:style-name="Bullet_20_Symbols" text:bullet-char="•">
+   <text:list-level-style-bullet text:level="7" text:style-name="Bullet_20_Symbols" loext:num-list-format="%7%" text:bullet-char="•">
     <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2in" fo:text-indent="-0.25in" fo:margin-left="2in"/>
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="5.08cm" fo:text-indent="-0.635cm" fo:margin-left="5.08cm"/>
     </style:list-level-properties>
    </text:list-level-style-bullet>
-   <text:list-level-style-bullet text:level="8" text:style-name="Bullet_20_Symbols" text:bullet-char="◦">
+   <text:list-level-style-bullet text:level="8" text:style-name="Bullet_20_Symbols" loext:num-list-format="%8%" text:bullet-char="◦">
     <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.25in" fo:text-indent="-0.25in" fo:margin-left="2.25in"/>
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="5.715cm" fo:text-indent="-0.635cm" fo:margin-left="5.715cm"/>
     </style:list-level-properties>
    </text:list-level-style-bullet>
-   <text:list-level-style-bullet text:level="9" text:style-name="Bullet_20_Symbols" text:bullet-char="▪">
+   <text:list-level-style-bullet text:level="9" text:style-name="Bullet_20_Symbols" loext:num-list-format="%9%" text:bullet-char="▪">
     <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.5in" fo:text-indent="-0.25in" fo:margin-left="2.5in"/>
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="6.35cm" fo:text-indent="-0.635cm" fo:margin-left="6.35cm"/>
     </style:list-level-properties>
    </text:list-level-style-bullet>
-   <text:list-level-style-bullet text:level="10" text:style-name="Bullet_20_Symbols" text:bullet-char="•">
+   <text:list-level-style-bullet text:level="10" text:style-name="Bullet_20_Symbols" loext:num-list-format="%10%" text:bullet-char="•">
     <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.75in" fo:text-indent="-0.25in" fo:margin-left="2.75in"/>
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="6.985cm" fo:text-indent="-0.635cm" fo:margin-left="6.985cm"/>
     </style:list-level-properties>
    </text:list-level-style-bullet>
   </text:list-style>
   <style:page-layout style:name="pm1">
-   <style:page-layout-properties fo:page-width="8.5in" fo:page-height="11in" style:num-format="1" style:print-orientation="portrait" fo:margin-top="0.7874in" fo:margin-bottom="0.5902in" fo:margin-left="0.7874in" fo:margin-right="0.7874in" style:writing-mode="lr-tb" style:layout-grid-color="#c0c0c0" style:layout-grid-lines="44" style:layout-grid-base-height="0.2165in" style:layout-grid-ruby-height="0in" style:layout-grid-mode="none" style:layout-grid-ruby-below="false" style:layout-grid-print="true" style:layout-grid-display="true" style:footnote-max-height="0in">
-    <style:footnote-sep style:width="0.0071in" style:distance-before-sep="0.0398in" style:distance-after-sep="0.0398in" style:line-style="none" style:adjustment="left" style:rel-width="25%" style:color="#000000"/>
+   <style:page-layout-properties fo:page-width="21.59cm" fo:page-height="27.94cm" style:num-format="1" style:print-orientation="portrait" fo:margin-top="2cm" fo:margin-bottom="1.499cm" fo:margin-left="2cm" fo:margin-right="2cm" style:writing-mode="lr-tb" style:layout-grid-color="#c0c0c0" style:layout-grid-lines="44" style:layout-grid-base-height="0.55cm" style:layout-grid-ruby-height="0cm" style:layout-grid-mode="none" style:layout-grid-ruby-below="false" style:layout-grid-print="true" style:layout-grid-display="true" style:footnote-max-height="0cm" loext:margin-gutter="0cm">
+    <style:footnote-sep style:width="0.018cm" style:distance-before-sep="0.101cm" style:distance-after-sep="0.101cm" style:line-style="none" style:adjustment="left" style:rel-width="25%" style:color="#000000"/>
    </style:page-layout-properties>
    <style:header-style>
-    <style:header-footer-properties fo:min-height="0.6307in" fo:margin-left="0in" fo:margin-right="0in" fo:margin-bottom="0.5902in" fo:background-color="transparent" style:dynamic-spacing="false" draw:fill="none" draw:fill-color="#2c83db"/>
+    <style:header-footer-properties fo:min-height="1.602cm" fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-bottom="1.499cm" fo:background-color="transparent" style:dynamic-spacing="false" draw:fill="none" draw:fill-color="#2c83db"/>
    </style:header-style>
    <style:footer-style>
-    <style:header-footer-properties fo:min-height="0in" fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0.1965in"/>
+    <style:header-footer-properties fo:min-height="0cm" fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0.499cm"/>
    </style:footer-style>
   </style:page-layout>
+  <style:style style:name="dp1" style:family="drawing-page">
+   <style:drawing-page-properties draw:background-size="full"/>
+  </style:style>
  </office:automatic-styles>
  <office:master-styles>
-  <style:master-page style:name="Standard" style:page-layout-name="pm1">
+  <style:master-page style:name="Standard" style:page-layout-name="pm1" draw:style-name="dp1">
    <style:header>
     <text:p text:style-name="P1"/>
-    <text:p text:style-name="P2">BREAST CANCER SCREENING REPORT<draw:frame draw:style-name="fr1" draw:name="image1.png" text:anchor-type="char" svg:x="5.3437in" svg:y="-0.25in" svg:width="1.6701in" svg:height="0.5047in" draw:z-index="1"><draw:image draw:mime-type="image/png">
+    <text:p text:style-name="P2">BREAST CANCER SCREENING REPORT<draw:frame draw:style-name="fr1" draw:name="image1.png" text:anchor-type="char" svg:x="13.573cm" svg:y="-0.635cm" svg:width="4.242cm" svg:height="1.282cm" draw:z-index="1"><draw:image draw:mime-type="image/png">
        <office:binary-data>iVBORw0KGgoAAAANSUhEUgAABTIAAAGQCAYAAACdy5+iAABvhUlEQVR4XuzdiVcVV9fn8f5r
         ez3JkyjOUaPGOc5R4xSnOMcBFXFAQBBFnEFERUQQQRBkUGYQSLX7Gvox+4Ay3Lr37KrvZ63f
         6tVv92s4t05B3V3nnP1/AgAAAAAAAADw3P/R/wMAAAAAAAAA8A2FTAAAAAAAAADeo5AJAAAA
@@ -2781,96 +3015,97 @@
     <text:sequence-decl text:display-outline-level="0" text:name="Drawing"/>
     <text:sequence-decl text:display-outline-level="0" text:name="Figure"/>
    </text:sequence-decls>
-   <text:p text:style-name="P253"><text:span text:style-name="T132"><text:placeholder text:placeholder-type="text">&lt;for each=&quot;patient in records&quot;&gt;</text:placeholder></text:span><text:span text:style-name="T5"><text:s/></text:span></text:p>
-   <text:p text:style-name="P158"><text:placeholder text:placeholder-type="text">&lt;replace text:p=&quot;set_lang(patient.name.lang)&quot;&gt;</text:placeholder><text:s/></text:p>
-   <text:p text:style-name="P22"><text:placeholder text:placeholder-type="text">&lt;replace text:p=&quot;patient.set_lang(patient.name.lang)&quot;&gt;</text:placeholder><text:s/></text:p>
-   <text:p text:style-name="P27"><text:span text:style-name="T99">Patient</text:span> <text:span text:style-name="T98">Name:</text:span> <text:span text:style-name="T89"><text:tab/> </text:span><text:span text:style-name="T25"><text:placeholder text:placeholder-type="text">&lt;patient.rec_name&gt;</text:placeholder></text:span><text:span text:style-name="T25"><text:s/></text:span><text:span text:style-name="T32"><text:line-break/></text:span><text:span text:style-name="T40">Patient</text:span> <text:span text:style-name="T41">’s Date of Birth:</text:span> <text:span text:style-name="T38"><text:tab/> </text:span><text:span text:style-name="T25"><text:placeholder text:placeholder-type="text">&lt;patient.dob and format_date(patient.dob, patient.name.lang)&gt;</text:placeholder></text:span><text:span text:style-name="T25"><text:s/></text:span></text:p>
-   <text:p text:style-name="P27"><text:span text:style-name="T43">Patient ID:<text:tab/></text:span> <text:span text:style-name="T26"><text:placeholder text:placeholder-type="text">&lt;patient.puid&gt;</text:placeholder></text:span><text:span text:style-name="T26"><text:s/></text:span><text:span text:style-name="T38"><text:line-break/></text:span><text:span text:style-name="T41">Date:</text:span> <text:span text:style-name="T38"><text:tab/> </text:span><text:span text:style-name="T25"><text:placeholder text:placeholder-type="text">&lt;format_date(today, patient.name.lang)&gt;</text:placeholder></text:span><text:span text:style-name="T25"><text:s/></text:span></text:p>
-   <text:p text:style-name="P72"><text:bookmark text:name="docs-internal-guid-36ad517f-7fff-c20e-59dd-e56bf9771450 Kopie 1"/><text:span text:style-name="T63">Date of Assessment:</text:span> <text:span text:style-name="T59"><text:tab/> </text:span><text:span text:style-name="T73"><text:placeholder text:placeholder-type="text">&lt;assessment_date and format_date(assessment_date, patient.name.lang)&gt;</text:placeholder></text:span><text:span text:style-name="T73"><text:s/></text:span></text:p>
-   <text:p text:style-name="P47"/>
-   <text:p text:style-name="P76"><text:placeholder text:placeholder-type="text">&lt;choose test=&quot;&quot;&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P76"><text:placeholder text:placeholder-type="text">&lt;when test=&quot;has_ultrasound_findings&quot;&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P126">Digital soft tissue mammography with ultrasound examination of both breasts, revealed:</text:p>
-   <text:p text:style-name="P139"><text:placeholder text:placeholder-type="text">&lt;/when&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P134"><text:placeholder text:placeholder-type="text">&lt;otherwise test=&quot;&quot;&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P125"><text:span text:style-name="T98">D</text:span><text:span text:style-name="T97">igital soft tissue mammography revealed:</text:span> </text:p>
-   <text:p text:style-name="P139"><text:placeholder text:placeholder-type="text">&lt;/otherwise&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P135"><text:placeholder text:placeholder-type="text">&lt;/choose&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P137"><text:placeholder text:placeholder-type="text">&lt;choose&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P136"><text:placeholder text:placeholder-type="text">&lt;when test=&quot;assessment and (assessment.code == &apos;1&apos; or assessment.code == &apos;2&apos;)&quot;&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P242">- Breast <text:span text:style-name="T138">d</text:span>ensity <text:span text:style-name="T138">(ACR)</text:span>: <text:placeholder text:placeholder-type="text">&lt;density&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P242">- No evidence of spiculated masses.</text:p>
-   <text:p text:style-name="P241">- No suspicious microcalcifications found.</text:p>
-   <text:p text:style-name="P241">- Absence of architectural distortions.</text:p>
-   <text:p text:style-name="P241">- Normal skin thickness &amp; contour of both breasts.</text:p>
-   <text:p text:style-name="P241">- Normal nipple / areola complexes on both sides.</text:p>
-   <text:p text:style-name="P244"><text:span text:style-name="T117">- Bilateral non-specific auxiliary lymph nodes.</text:span><text:span text:style-name="T106"> </text:span></text:p>
-   <text:p text:style-name="P101"><text:placeholder text:placeholder-type="text">&lt;/when&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P138"><text:placeholder text:placeholder-type="text">&lt;otherwise test=&quot;&quot;&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P138"><text:span text:style-name="T106">- Breast </text:span><text:span text:style-name="T121">d</text:span><text:span text:style-name="T106">ensity </text:span><text:span text:style-name="T121">(ACR)</text:span><text:span text:style-name="T106">: </text:span><text:span text:style-name="T106"><text:placeholder text:placeholder-type="text">&lt;density&gt;</text:placeholder></text:span></text:p>
-   <text:p text:style-name="P97"><text:placeholder text:placeholder-type="text">&lt;/otherwise&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P98"><text:placeholder text:placeholder-type="text">&lt;/choose&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P79"><text:placeholder text:placeholder-type="text">&lt;for each=&quot;finding in findings&quot;&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P45"><text:span text:style-name="T37">- <text:s/></text:span><text:span text:style-name="T37"><text:placeholder text:placeholder-type="text">&lt;finding.method_string&gt;</text:placeholder></text:span><text:span text:style-name="T37"><text:s/>showed </text:span><text:span text:style-name="T37"><text:placeholder text:placeholder-type="text">&lt;finding.lesion_type&gt;</text:placeholder></text:span><text:span text:style-name="T37"><text:s/>in </text:span><text:span text:style-name="T37"><text:placeholder text:placeholder-type="text">&lt;finding.laterality_string&gt;</text:placeholder></text:span><text:span text:style-name="T37"><text:s/>at </text:span><text:span text:style-name="T37"><text:placeholder text:placeholder-type="text">&lt;finding.localisation&gt;</text:placeholder></text:span><text:span text:style-name="T37"><text:s/>measuring </text:span><text:span text:style-name="T37"><text:placeholder text:placeholder-type="text">&lt;finding.size&gt;</text:placeholder></text:span><text:span text:style-name="T37">mm.</text:span></text:p>
-   <text:p text:style-name="P70"><text:placeholder text:placeholder-type="text">&lt;if test=&quot;finding.comment&quot;&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P45"><text:span text:style-name="T84"><text:s text:c="2"/></text:span><text:span text:style-name="T44">Comment</text:span><text:span text:style-name="T49">: </text:span><text:span text:style-name="T37"><text:placeholder text:placeholder-type="text">&lt;finding.comment&gt;</text:placeholder></text:span><text:span text:style-name="T37"><text:s/></text:span></text:p>
-   <text:p text:style-name="P70"><text:placeholder text:placeholder-type="text">&lt;/if&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P77"><text:placeholder text:placeholder-type="text">&lt;/for&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P74"><text:placeholder text:placeholder-type="text">&lt;if test=&quot;patient.general_info&quot;&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P78"/>
-   <text:p text:style-name="P8"><text:placeholder text:placeholder-type="text">&lt;for each=&quot;line in patient.general_info.split(&apos;\n&apos;)&quot;&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P8"><text:placeholder text:placeholder-type="text">&lt;line&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P8"><text:placeholder text:placeholder-type="text">&lt;/for&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P8"/>
-   <text:p text:style-name="P81"><text:span text:style-name="T45"><text:placeholder text:placeholder-type="text">&lt;/if&gt;</text:placeholder></text:span><text:span text:style-name="T120"><text:line-break/></text:span></text:p>
-   <text:p text:style-name="P81"><text:span text:style-name="T115">BIRADS</text:span><text:span text:style-name="T118">: </text:span><text:span text:style-name="T113"><text:placeholder text:placeholder-type="text">&lt;assessment and assessment.code&gt;</text:placeholder></text:span></text:p>
-   <text:p text:style-name="P154"><text:placeholder text:placeholder-type="text">&lt;if test=&quot;patient.opinion&quot;&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P90"><text:soft-page-break/></text:p>
-   <text:p text:style-name="P90">Opinion:</text:p>
-   <text:p text:style-name="P266"><text:placeholder text:placeholder-type="text">&lt;for each=&quot;line in patient.opinion.split(&apos;\n&apos;)&quot;&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P266"><text:placeholder text:placeholder-type="text">&lt;line&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P266"><text:placeholder text:placeholder-type="text">&lt;/for&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P68"><text:placeholder text:placeholder-type="text">&lt;/if&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P68"><text:placeholder text:placeholder-type="text">&lt;if test=&quot;patient.recommendation&quot;&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P90"/>
-   <text:p text:style-name="P271"><text:span text:style-name="T64">Recommendation:</text:span></text:p>
-   <text:p text:style-name="P266"><text:placeholder text:placeholder-type="text">&lt;for each=&quot;line in patient.recommendation.split(&apos;\n&apos;)&quot;&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P266"><text:placeholder text:placeholder-type="text">&lt;line&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P266"><text:placeholder text:placeholder-type="text">&lt;/for&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P69"><text:placeholder text:placeholder-type="text">&lt;/if&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P69"><text:placeholder text:placeholder-type="text">&lt;if test=&quot;(not patient.recommendation) and (assessment and (assessment.code == &apos;1&apos; or assessment.code == &apos;2&apos;))&quot;&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P91"/>
-   <text:p text:style-name="P84"><text:span text:style-name="T85">Recommendation:</text:span><text:span text:style-name="T87"> </text:span><text:span text:style-name="T109">Follow-up screening in one year.</text:span></text:p>
-   <text:p text:style-name="P68"><text:placeholder text:placeholder-type="text">&lt;/if&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P56">Best regards,</text:p>
-   <text:p text:style-name="P147"><text:placeholder text:placeholder-type="text">&lt;doctor and doctor.name.rec_name&gt;</text:placeholder></text:p>
-   <text:p text:style-name="P148"><text:s/><text:placeholder text:placeholder-type="text">&lt;/for&gt;</text:placeholder><text:s/></text:p>
-   <text:p text:style-name="P60">BIRADS classification of breast lesions according to the American College of Radiology used for breast assessment combined with recommendations:</text:p>
-   <text:p text:style-name="P60">Category &amp; recommendations<text:span text:style-name="T37"><text:tab/><text:tab/><text:tab/></text:span>Suspected Cancer Risk</text:p>
-   <text:p text:style-name="P62">BIRADS 0: Non-informative study.</text:p>
-   <text:p text:style-name="P62">BIRADS 1: Normal study, routine screening.<text:tab/><text:tab/><text:tab/>0 %</text:p>
-   <text:p text:style-name="P62">BIRADS 2: Benign findings, routine screening.<text:tab/><text:tab/>0 %</text:p>
-   <text:p text:style-name="P62">BIRADS 3: Probably benign, for close follow up.<text:tab/><text:tab/>2 %</text:p>
-   <text:p text:style-name="P62">BIRADS 4: Probably malignant, for biopsy.<text:tab/><text:tab/><text:tab/>50 %</text:p>
-   <text:p text:style-name="P62"><text:tab/> <text:s text:c="2"/>A: mild suspicion.</text:p>
-   <text:p text:style-name="P62"><text:tab/> <text:s text:c="2"/>B: moderate suspicion.</text:p>
-   <text:p text:style-name="P62"><text:tab/> <text:s text:c="2"/>C: high suspicion.</text:p>
-   <text:p text:style-name="P62">BIRADS 5: Malignant, for biopsy.<text:tab/><text:tab/><text:tab/><text:tab/>98-100 %</text:p>
-   <text:p text:style-name="P62">BIRADS 6: Pathologically proven malignant lesion.</text:p>
-   <text:p text:style-name="P62"/>
-   <text:p text:style-name="P61">American college of radiology (ACR) scoring of breast density:</text:p>
-   <text:list xml:id="list3557582522" text:style-name="L1">
+   <text:p text:style-name="P283"><text:span text:style-name="T145"><text:placeholder text:placeholder-type="text">&lt;for each=&quot;patient in records&quot;&gt;</text:placeholder></text:span><text:span text:style-name="T126"><text:s/></text:span></text:p>
+   <text:p text:style-name="P63"><text:placeholder text:placeholder-type="text">&lt;replace text:p=&quot;set_lang(patient.name.lang)&quot;&gt;</text:placeholder><text:s/></text:p>
+   <text:p text:style-name="P73"><text:placeholder text:placeholder-type="text">&lt;replace text:p=&quot;patient.set_lang(patient.name.lang)&quot;&gt;</text:placeholder><text:s/></text:p>
+   <text:p text:style-name="P285"><text:span text:style-name="T103">Patient</text:span> <text:span text:style-name="T102">Name:</text:span> <text:span text:style-name="T93"><text:tab/> </text:span><text:span text:style-name="T38"><text:placeholder text:placeholder-type="text">&lt;patient.rec_name&gt;</text:placeholder></text:span><text:span text:style-name="T38"><text:s/></text:span><text:span text:style-name="T32"><text:line-break/></text:span><text:span text:style-name="T40">Patient</text:span><text:span text:style-name="T41">’s Date of Birth:</text:span> <text:span text:style-name="T38"><text:tab/> </text:span><text:span text:style-name="T38"><text:placeholder text:placeholder-type="text">&lt;patient.dob and format_date(patient.dob, patient.name.lang)&gt;</text:placeholder></text:span><text:span text:style-name="T38"><text:s/></text:span></text:p>
+   <text:p text:style-name="P285"><text:span text:style-name="T43">Patient ID:<text:tab/></text:span> <text:span text:style-name="T49"><text:placeholder text:placeholder-type="text">&lt;patient.puid&gt;</text:placeholder></text:span><text:span text:style-name="T49"><text:s/></text:span><text:span text:style-name="T38"><text:line-break/></text:span><text:span text:style-name="T41">Date:</text:span> <text:span text:style-name="T38"><text:tab/> </text:span><text:span text:style-name="T38"><text:placeholder text:placeholder-type="text">&lt;format_date(today, patient.name.lang)&gt;</text:placeholder></text:span><text:span text:style-name="T38"><text:s/></text:span></text:p>
+   <text:p text:style-name="P287"><text:bookmark text:name="docs-internal-guid-36ad517f-7fff-c20e-59dd-e56bf9771450 Kopie 1"/><text:span text:style-name="T65">Date of Assessment:</text:span> <text:span text:style-name="T61"><text:tab/> </text:span><text:span text:style-name="T61"><text:placeholder text:placeholder-type="text">&lt;assessment_date and format_date(assessment_date, patient.name.lang)&gt;</text:placeholder></text:span><text:span text:style-name="T61"><text:s/></text:span></text:p>
+   <text:p text:style-name="P106"/>
+   <text:p text:style-name="P288"><text:placeholder text:placeholder-type="text">&lt;choose test=&quot;&quot;&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P288"><text:placeholder text:placeholder-type="text">&lt;when test=&quot;has_ultrasound_findings&quot;&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P294">Digital soft tissue mammography with ultrasound examination of both breasts, revealed:</text:p>
+   <text:p text:style-name="P295"><text:placeholder text:placeholder-type="text">&lt;/when&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P304"><text:span text:style-name="T101"><text:placeholder text:placeholder-type="text">&lt;otherwise test=&quot;&quot;&gt;</text:placeholder></text:span></text:p>
+   <text:p text:style-name="P304"><text:span text:style-name="T131">D</text:span><text:span text:style-name="T130">igital soft tissue mammography revealed:</text:span><text:span text:style-name="T127"> </text:span></text:p>
+   <text:p text:style-name="P295"><text:placeholder text:placeholder-type="text">&lt;/otherwise&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P296"><text:placeholder text:placeholder-type="text">&lt;/choose&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P298"><text:placeholder text:placeholder-type="text">&lt;choose&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P300"><text:placeholder text:placeholder-type="text">&lt;when test=&quot;assessment and (assessment.code == &apos;1&apos; or assessment.code == &apos;2&apos;)&quot;&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P299">- Breast <text:span text:style-name="T143">d</text:span>ensity <text:span text:style-name="T143">(ACR)</text:span>: <text:placeholder text:placeholder-type="text">&lt;density&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P299">- No evidence of spiculated masses.</text:p>
+   <text:p text:style-name="P297">- No suspicious microcalcifications found.</text:p>
+   <text:p text:style-name="P297">- Absence of architectural distortions.</text:p>
+   <text:p text:style-name="P297">- Normal skin thickness &amp; contour of both breasts.</text:p>
+   <text:p text:style-name="P297">- Normal nipple / areola complexes on both sides.</text:p>
+   <text:p text:style-name="P305"><text:span text:style-name="T45">- Bilateral non-specific axillary lymph nodes.</text:span></text:p>
+   <text:p text:style-name="P306"><text:placeholder text:placeholder-type="text">&lt;/when&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P301"><text:placeholder text:placeholder-type="text">&lt;otherwise test=&quot;&quot;&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P301">- Breast <text:span text:style-name="T143">d</text:span>ensity <text:span text:style-name="T143">(ACR)</text:span>: <text:placeholder text:placeholder-type="text">&lt;density&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P302"><text:placeholder text:placeholder-type="text">&lt;/otherwise&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P303"><text:placeholder text:placeholder-type="text">&lt;/choose&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P289"><text:placeholder text:placeholder-type="text">&lt;for each=&quot;finding in findings&quot;&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P91"><text:span text:style-name="T37">- </text:span><text:span text:style-name="T37"><text:placeholder text:placeholder-type="text">&lt;finding.method_string&gt;</text:placeholder></text:span><text:span text:style-name="T37"><text:s/>showed </text:span><text:span text:style-name="T37"><text:placeholder text:placeholder-type="text">&lt;finding.lesion_type&gt;</text:placeholder></text:span><text:span text:style-name="T37"><text:s/>in </text:span><text:span text:style-name="T37"><text:placeholder text:placeholder-type="text">&lt;finding.laterality_string&gt;</text:placeholder></text:span><text:span text:style-name="T37"><text:s/>at </text:span><text:span text:style-name="T37"><text:placeholder text:placeholder-type="text">&lt;finding.localisation&gt;</text:placeholder></text:span><text:span text:style-name="T37"><text:s/>measuring </text:span><text:span text:style-name="T37"><text:placeholder text:placeholder-type="text">&lt;finding.size&gt;</text:placeholder></text:span><text:span text:style-name="T37">mm.</text:span></text:p>
+   <text:p text:style-name="P274"><text:placeholder text:placeholder-type="text">&lt;if test=&quot;finding.comment&quot;&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P91"><text:span text:style-name="T90"><text:s text:c="2"/></text:span><text:span text:style-name="T44">Comment</text:span><text:span text:style-name="T50">: </text:span><text:span text:style-name="T37"><text:placeholder text:placeholder-type="text">&lt;finding.comment&gt;</text:placeholder></text:span></text:p>
+   <text:p text:style-name="P274"><text:placeholder text:placeholder-type="text">&lt;/if&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P291"><text:placeholder text:placeholder-type="text">&lt;/for&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P292"><text:placeholder text:placeholder-type="text">&lt;if test=&quot;patient.general_info&quot;&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P292"/>
+   <text:p text:style-name="P268"><text:placeholder text:placeholder-type="text">&lt;for each=&quot;line in patient.general_info.split(&apos;\n&apos;)&quot;&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P268"><text:placeholder text:placeholder-type="text">&lt;line&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P268"><text:placeholder text:placeholder-type="text">&lt;/for&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P268"/>
+   <text:p text:style-name="P293"><text:span text:style-name="T45"><text:placeholder text:placeholder-type="text">&lt;/if&gt;</text:placeholder></text:span></text:p>
+   <text:p text:style-name="P293"><text:span text:style-name="T43"/></text:p>
+   <text:p text:style-name="P293"><text:span text:style-name="T40">BIRADS</text:span><text:span text:style-name="T39">: </text:span><text:span text:style-name="T45"><text:placeholder text:placeholder-type="text">&lt;assessment and assessment.code&gt;</text:placeholder></text:span></text:p>
+   <text:p text:style-name="P280"><text:placeholder text:placeholder-type="text">&lt;if test=&quot;patient.opinion&quot;&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P308"/>
+   <text:p text:style-name="P308"><text:soft-page-break/>Opinion:</text:p>
+   <text:p text:style-name="P269"><text:placeholder text:placeholder-type="text">&lt;for each=&quot;line in patient.opinion.split(&apos;\n&apos;)&quot;&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P269"><text:placeholder text:placeholder-type="text">&lt;line&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P269"><text:placeholder text:placeholder-type="text">&lt;/for&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P275"><text:placeholder text:placeholder-type="text">&lt;/if&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P275"><text:placeholder text:placeholder-type="text">&lt;if test=&quot;patient.recommendation&quot;&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P308"/>
+   <text:p text:style-name="P308">Recommendation:</text:p>
+   <text:p text:style-name="P269"><text:placeholder text:placeholder-type="text">&lt;for each=&quot;line in patient.recommendation.split(&apos;\n&apos;)&quot;&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P269"><text:placeholder text:placeholder-type="text">&lt;line&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P269"><text:placeholder text:placeholder-type="text">&lt;/for&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P276"><text:placeholder text:placeholder-type="text">&lt;/if&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P276"><text:placeholder text:placeholder-type="text">&lt;if test=&quot;(not patient.recommendation) and (assessment and (assessment.code == &apos;1&apos; or assessment.code == &apos;2&apos;))&quot;&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P309"/>
+   <text:p text:style-name="P307"><text:span text:style-name="T54">Recommendation:</text:span><text:span text:style-name="T91"> </text:span><text:span text:style-name="T144">Follow-up screening in one year.</text:span></text:p>
+   <text:p text:style-name="P275"><text:placeholder text:placeholder-type="text">&lt;/if&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P139">Best regards,</text:p>
+   <text:p text:style-name="P133"><text:placeholder text:placeholder-type="text">&lt;doctor and doctor.name.rec_name&gt;</text:placeholder></text:p>
+   <text:p text:style-name="P135"><text:s/><text:placeholder text:placeholder-type="text">&lt;/for&gt;</text:placeholder><text:s/></text:p>
+   <text:p text:style-name="P148">BIRADS classification of breast lesions according to the American College of Radiology used for breast assessment combined with recommendations:</text:p>
+   <text:p text:style-name="P148">Category &amp; recommendations<text:span text:style-name="T37"><text:tab/><text:tab/><text:tab/></text:span>Suspected Cancer Risk</text:p>
+   <text:p text:style-name="P145">BIRADS 0: Non-informative study.</text:p>
+   <text:p text:style-name="P145">BIRADS 1: Normal study, routine screening.<text:tab/><text:tab/><text:tab/>0 %</text:p>
+   <text:p text:style-name="P145">BIRADS 2: Benign findings, routine screening.<text:tab/><text:tab/>0 %</text:p>
+   <text:p text:style-name="P145">BIRADS 3: Probably benign, for close follow up.<text:tab/><text:tab/>2 %</text:p>
+   <text:p text:style-name="P145">BIRADS 4: Probably malignant, for biopsy.<text:tab/><text:tab/><text:tab/>50 %</text:p>
+   <text:p text:style-name="P145"><text:tab/> <text:s text:c="2"/>A: mild suspicion.</text:p>
+   <text:p text:style-name="P145"><text:tab/> <text:s text:c="2"/>B: moderate suspicion.</text:p>
+   <text:p text:style-name="P145"><text:tab/> <text:s text:c="2"/>C: high suspicion.</text:p>
+   <text:p text:style-name="P145">BIRADS 5: Malignant, for biopsy.<text:tab/><text:tab/><text:tab/><text:tab/>98-100 %</text:p>
+   <text:p text:style-name="P145">BIRADS 6: Pathologically proven malignant lesion.</text:p>
+   <text:p text:style-name="P145"/>
+   <text:p text:style-name="P149">American college of radiology (ACR) scoring of breast density:</text:p>
+   <text:list text:style-name="L1">
     <text:list-item>
-     <text:p text:style-name="P267"><text:span text:style-name="T31">ACR. </text:span><text:span text:style-name="T36">A</text:span><text:span text:style-name="T31">:</text:span> almost entirely fatty.</text:p>
+     <text:p text:style-name="P279"><text:span text:style-name="T31">ACR. </text:span><text:span text:style-name="T36">A</text:span><text:span text:style-name="T31">:</text:span> almost entirely fatty.</text:p>
     </text:list-item>
     <text:list-item>
-     <text:p text:style-name="P268"><text:span text:style-name="T31">ACR. </text:span><text:span text:style-name="T36">B</text:span><text:span text:style-name="T31">:</text:span> scattered areas of fibro-glandular density.</text:p>
+     <text:p text:style-name="P278"><text:span text:style-name="T31">ACR. </text:span><text:span text:style-name="T36">B</text:span><text:span text:style-name="T31">:</text:span> scattered areas of fibro-glandular density.</text:p>
     </text:list-item>
     <text:list-item>
-     <text:p text:style-name="P268"><text:span text:style-name="T31">ACR. </text:span><text:span text:style-name="T36">C</text:span><text:span text:style-name="T31">:</text:span> heterogenously dense.</text:p>
+     <text:p text:style-name="P278"><text:span text:style-name="T31">ACR. </text:span><text:span text:style-name="T36">C</text:span><text:span text:style-name="T31">:</text:span> heterogenously dense.</text:p>
     </text:list-item>
     <text:list-item>
-     <text:p text:style-name="P268"><text:span text:style-name="T31">ACR. </text:span><text:span text:style-name="T36">D</text:span><text:span text:style-name="T31">:</text:span> extremely dense.</text:p>
+     <text:p text:style-name="P278"><text:span text:style-name="T31">ACR. </text:span><text:span text:style-name="T36">D</text:span><text:span text:style-name="T31">:</text:span> extremely dense.</text:p>
     </text:list-item>
    </text:list>
   </office:text>


### PR DESCRIPTION
There was a bug found:
If the image request assessment had birads of 2
and other findings had birads 3
the final assessment would be chosen as 2 from the image request.
We want to always make sure we take the highest applicable birads score.

This also fixed a few typos and formattings in the report template, e.g:
auxiliary -> axillary
patient 's -> patient's