### PR TITLE
Update gender options

### DIFF
--- a/health_vara.py
+++ b/health_vara.py
@@ -170,10 +170,6 @@ class MammographyPatient(metaclass=PoolMeta):
                     (None, ''),
                     ('m', 'Male'),
                     ('f', 'Female'),
-                    ('nb', 'Non-binary'),
-                    ('other', 'Other'),
-                    ('nd', 'Non disclosed'),
-                    ('u', 'Unknown'),
                 ])
 
         # ensures all the patient fields that should pass on values to party


### PR DESCRIPTION
This feels a bit wrong, but it seems VaraMG already only supports Female or Male as gender, so this makes GNUHealth match

![image](https://github.com/vara-ai/health_vara/assets/1367955/62b09fb4-edd5-4c78-918e-2f6e8853b4d3)

https://app.asana.com/0/0/1205190163181318/1205196224236911/f