### PR TITLE
Look for 'en' as a translatable language to use if it exists.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -11,6 +11,7 @@ __all__ = ['register']
 
 def register():
     Pool.register(
+        health_vara.User,
         health_vara.Party,
         health_vara.MammographyPatient,
         health_vara.PatientEvaluation,

--- a/health_vara.py
+++ b/health_vara.py
@@ -7,6 +7,24 @@ from trytond.pyson import Bool, Eval
 import re
 
 
+
+class User(metaclass=PoolMeta):
+    __name__ = 'res.user'
+
+    @staticmethod
+    def default_language():
+        preferred_language = 'en'
+
+        Lang = Pool().get('ir.lang')
+        languages = Lang.search([
+            ('code', '=', preferred_language),
+            ('translatable', '=', True)
+        ])
+
+        if len(languages) > 0:
+            return languages[0].id
+
+
 def normalise_mobile_number(value):
     # treat whitespace-only values the same as None
     value = None if (value is None) or (value == '') or (value.isspace()) else value


### PR DESCRIPTION
Defaults to 'en' if we find it as an existing, translatable language.