### PR TITLE
Deactivate VPP patient report and free text fields

### DIFF
--- a/health_vara_report.xml
+++ b/health_vara_report.xml
@@ -11,6 +11,9 @@ contains the full copyright notices and license terms. -->
             <field name="report_name">patient.vara.findings</field>
             <field name="report">health_vara/report/patient_vara_findings.fodt</field>
             <field name="extension">pdf</field>
+            <!-- it is considered unsafe to produce this report right now. Disabling rather than deleting and leaving
+                 the code since I don't want to find how to do it again in future-->
+            <field name="active" eval="False"/>
         </record>
         <record model="ir.action.keyword" id="report_patient_vara_findings_keyword">
             <field name="keyword">form_print</field>

--- a/view/mammography_patient_form.xml
+++ b/view/mammography_patient_form.xml
@@ -49,22 +49,6 @@ contains the full copyright notices and license terms. -->
             <group id="patient_findings">
                 <field name="findings" string="" colspan="4"/>
             </group>
-            <separator string="Biopsies" id="sep_patient_biopsies" colspan="4"/>
-            <group id="patient_biopsies">
-                <field name="biopsies" string="" colspan="4"/>
-            </group>
-            <separator string="General Observations" id="sep_patient_other_info" colspan="4"/>
-            <group id="patient_other_info">
-                <field name="general_info" colspan="4"/>
-            </group>
-            <separator string="Opinion" id="sep_patient_opinion" colspan="4"/>
-            <group id="patient_opinion">
-                <field name="opinion" colspan="4"/>
-            </group>
-            <separator string="Recommendation" id="sep_patient_recommendation" colspan="4"/>
-            <group id="patient_recommendation">
-                <field name="recommendation" colspan="4"/>
-            </group>
         </form>
     </xpath>
 </data>


### PR DESCRIPTION
https://app.asana.com/0/1206336752074994/1206691706446517/f
This implements changes by hiding the functionality, rather than completely deleting the data. This is less lossy, and IMO less risky since the "migration" change is more obvious.

I have not done one of the desirable things from the ticket, of keeping the report for BIRADS 1/2 cases since apparently this is not possible with the current report button without more extensive changes.
https://discuss.tryton.org/t/hide-ir-action-keyword-depending-on-state/5096/5

----

Technically I have not been able to run this code as is, I had to disable some access setup `access_health_genetics_disease_gene_medical_assistant`, I'm confident this is unrelated and instead due to some weird database state I have achieved. With that commented out, it runs and functions as expected for me.
I've left it in since it already exists in production and seemingly is working with the database states there.